### PR TITLE
PDC-7: Update subscriber independent device synchronization operation

### DIFF
--- a/src/lib/DataSubscriber.cs
+++ b/src/lib/DataSubscriber.cs
@@ -3185,7 +3185,7 @@ namespace sttp
                                                                                        "acronym", "name", "originalSource", "protocolID", "framesPerSecond", "historianID", "accessID", "longitude", "latitude", "contactList", "uniqueID");
 
                             string updateDeviceWithConnectionStringSql = database.ParameterizedQueryString("UPDATE Device SET Acronym = {0}, Name = {1}, OriginalSource = {2}, ProtocolID = {3}, FramesPerSecond = {4}, HistorianID = {5}, AccessID = {6}, Longitude = {7}, Latitude = {8}, ContactList = {9}, ConnectionString = {10} WHERE UniqueID = {11}",
-                                "acronym", "name", "originalSource", "protocolID", "framesPerSecond", "historianID", "accessID", "longitude", "latitude", "contactList", "connectionString", "uniqueID");
+                                                                                                           "acronym", "name", "originalSource", "protocolID", "framesPerSecond", "historianID", "accessID", "longitude", "latitude", "contactList", "connectionString", "uniqueID");
 
                             // Define SQL statement to retrieve device's auto-inc ID based on its unique guid-based ID
                             string queryDeviceIDSql = database.ParameterizedQueryString("SELECT ID FROM Device WHERE UniqueID = {0}", "uniqueID");

--- a/src/lib/DataSubscriber.cs
+++ b/src/lib/DataSubscriber.cs
@@ -727,9 +727,10 @@ namespace sttp
         /// </summary>
         /// <remarks>
         /// This is useful when using an STTP connection to only synchronize metadata from a publisher, but not to receive data. When enabled,
-        /// the device enabled state will not be synchronized. In this mode it may be useful to add the original "ConnectionString" field to
-        /// the publisher's device metadata so it can be synchronized to the subscriber. To ensure no data is received, the subscriber should
-        /// be configured with an "OutputMeasurements" filter in the adapter's connection string that does not include any measurements, e.g.:
+        /// the device enabled state will not synchronized upon creation unless <see cref="AutoEnableIndependentlySyncedDevices"/> is set to
+        /// <c>true</c>. In this mode it may be useful to add the original "ConnectionString" field to the publisher's device metadata so it can
+        /// be synchronized to the subscriber. To ensure no data is received, the subscriber should be configured with an "OutputMeasurements"
+        /// filter in the adapter's connection string that does not include any measurements, e.g.:
         /// <code>outputMeasurements={FILTER ActiveMeasurements WHERE False}</code>
         /// </remarks>
         public bool SyncIndependentDevices { get; set; }
@@ -1021,7 +1022,10 @@ namespace sttp
                 status.AppendLine($"  Auto delete CALC signals: {AutoDeleteCalculatedMeasurements}");
                 status.AppendLine($"  Auto delete ALRM signals: {AutoDeleteAlarmMeasurements}");
                 status.AppendLine($"  Sync independent devices: {SyncIndependentDevices}");
-                status.AppendLine($"Independent synced devices: {(AutoEnableIndependentlySyncedDevices? "enabled" : "disabled")} on creation");
+
+                if (SyncIndependentDevices)
+                    status.AppendLine($"Independent synced devices: {(AutoEnableIndependentlySyncedDevices? "enabled" : "disabled")} on creation");
+
                 status.AppendLine($"  Bypass statistics engine: {BypassStatistics}");
                 status.AppendLine($"      Total bytes received: {TotalBytesReceived:N0}");
                 status.AppendLine($"      Data packet security: {(m_securityMode == SecurityMode.TLS && m_dataChannel is null ? "Secured via TLS" : m_keyIVs is null ? "Unencrypted" : "AES Encrypted")}");

--- a/src/lib/DataSubscriber.cs
+++ b/src/lib/DataSubscriber.cs
@@ -723,6 +723,7 @@ namespace sttp
         /// <summary>
         /// Gets or sets flag that determines if the data subscriber should attempt to synchronize device metadata as independent devices, i.e.,
         /// not as children of the parent STTP device connection.
+        /// Defaults to <c>false</c>.
         /// </summary>
         /// <remarks>
         /// This is useful when using an STTP connection to only synchronize metadata from a publisher, but not to receive data. When enabled,
@@ -735,7 +736,7 @@ namespace sttp
 
         /// <summary>
         /// Gets or sets flag that determines if the data subscriber should automatically enable independently synced devices.
-        /// Default to <c>false</c>.
+        /// Defaults to <c>false</c>.
         /// </summary>
         public bool AutoEnableIndependentlySyncedDevices { get; set; }
 


### PR DESCRIPTION
This updates independent subscriber synchronization operation to not overwrite connection string when field is not included in source metadata.