### PR TITLE
Increment decoder sequence number before decoding measurements

### DIFF
--- a/src/lib/DataSubscriber.cs
+++ b/src/lib/DataSubscriber.cs
@@ -2982,6 +2982,12 @@ public class DataSubscriber : InputAdapterBase
             return;
         }
 
+        decoder.SequenceNumber++;
+
+        // Do not increment to 0 on roll-over
+        if (decoder.SequenceNumber == 0)
+            decoder.SequenceNumber = 1;
+
         decoder.SetBuffer(buffer, responseIndex, packetLength - 3);
 
         while (decoder.TryGetMeasurement(out int id, out long time, out uint quality, out float value))
@@ -2999,12 +3005,6 @@ public class DataSubscriber : InputAdapterBase
 
             measurements.Add(measurement);
         }
-
-        decoder.SequenceNumber++;
-
-        // Do not increment to 0 on roll-over
-        if (decoder.SequenceNumber == 0)
-            decoder.SequenceNumber = 1;
     }
 
     private static bool IsUserCommand(ServerCommand command)


### PR DESCRIPTION
By moving this up, we ensure that the sequence number gets incremented even if we somehow encounter an exception while decoding measurements.