### PR TITLE
IEEE 2664 buffer block sync

### DIFF
--- a/src/lib/sttp.core/DataPublisher.cs
+++ b/src/lib/sttp.core/DataPublisher.cs
@@ -2680,7 +2680,8 @@ public class DataPublisher : ActionAdapterCollection, IOptimizedRoutingConsumer
         {
             // Create a new working buffer
             bool dataPacketResponse = responseCode == (byte)ServerResponse.DataPacket;
-            bool useDataChannel = dataPacketResponse || responseCode == (byte)ServerResponse.BufferBlock;
+            bool bufferBlockResponse = responseCode == (byte)ServerResponse.BufferBlock;
+            bool useDataChannel = dataPacketResponse || bufferBlockResponse;
 
             // Initialize target working buffer
             workingBuffer = MaxPublishInterval == 0L ? new BlockAllocatedMemoryStream() : connection.PublishBuffer;
@@ -2725,6 +2726,52 @@ public class DataPublisher : ActionAdapterCollection, IOptimizedRoutingConsumer
                     Common.SymmetricAlgorithm.Encrypt(sourceData, workingBuffer, keyIVs[cipherIndex][0], keyIVs[cipherIndex][1]);
 
                     // Calculate length of encrypted data payload
+                    int payloadLength = (int)workingBuffer.Length - 6;
+
+                    // Move the response packet position back to the packet size reservation
+                    workingBuffer.Seek(2, SeekOrigin.Begin);
+
+                    // Add the actual size of payload length to response packet
+                    workingBuffer.Write(BigEndian.GetBytes(payloadLength), 0, 4);
+                }
+                // If response is for a buffer block and a connection key is defined, encrypt the
+                // buffer block payload. Parallel to the DATA PACKET branch above, modeled per
+                // IEEE Std 2664-2024 § 5.5.10: "When UDP encryption is established with the
+                // UPDATE CIPHER KEYS response, data is encrypted and replaces the BUFFER BLOCK
+                // PAYLOAD." SEQUENCE VALUE and FLAGS stay cleartext - the subscriber needs them
+                // to dedup retransmits and choose the correct cipher key set before decryption.
+                // SIGNAL INDEX and PAYLOAD are encrypted together (the parallel to DATA PACKET
+                // encrypting MEASUREMENT COUNT + PAYLOAD).
+                else if (bufferBlockResponse && connection.KeyIVs is not null)
+                {
+                    // Get a local copy of volatile keyIVs and cipher index since these can change at any time
+                    byte[][][] keyIVs = connection.KeyIVs;
+                    int cipherIndex = connection.CipherIndex;
+
+                    // Reserve space for size of data buffer to go into response packet
+                    workingBuffer.Write(s_zeroLengthBytes, 0, 4);
+
+                    // Write SEQUENCE VALUE cleartext (4 bytes)
+                    workingBuffer.Write(data, 0, 4);
+
+                    // Get buffer block flags
+                    BufferBlockFlags flags = (BufferBlockFlags)data[4];
+
+                    // Encode current cipher index into buffer block flags (KEY INDEX, Table 8 bit 0x04)
+                    if (cipherIndex > 0)
+                        flags |= BufferBlockFlags.KeyIndex;
+
+                    // Write buffer block flags into response packet
+                    workingBuffer.WriteByte((byte)flags);
+
+                    // Copy SIGNAL INDEX + PAYLOAD into a memory stream for encryption
+                    MemoryStream sourceData = new(data, 5, data.Length - 5);
+
+                    // Encrypt payload portion of buffer block and copy into the response packet
+                    Common.SymmetricAlgorithm.Encrypt(sourceData, workingBuffer, keyIVs[cipherIndex][0], keyIVs[cipherIndex][1]);
+
+                    // Calculate length of encrypted payload (response packet length minus the
+                    // 6-byte ClientResponseHeader, which is response code + command code + size field)
                     int payloadLength = (int)workingBuffer.Length - 6;
 
                     // Move the response packet position back to the packet size reservation

--- a/src/lib/sttp.core/DataPublisher.cs
+++ b/src/lib/sttp.core/DataPublisher.cs
@@ -477,6 +477,56 @@ public enum DataPacketFlags : byte
 }
 
 /// <summary>
+/// <see cref="DataPublisher"/> buffer block flags.
+/// </summary>
+/// <remarks>
+/// These flags occupy the single byte at offset +4 of the <see cref="ServerResponse.BufferBlock"/>
+/// payload, immediately after the 4-byte SEQUENCE VALUE. Bit definitions follow IEEE Std
+/// 2664-2024 Table 8 and are intentionally parallel to <see cref="DataPacketFlags"/>.
+/// </remarks>
+[Flags]
+public enum BufferBlockFlags : byte
+{
+    /// <summary>
+    /// No flags set.
+    /// </summary>
+    NoFlags = (byte)Bits.Nil,
+
+    /// <summary>
+    /// Determines if BUFFER BLOCK requires confirmation with a CONFIRM BUFFER BLOCK command.
+    /// </summary>
+    /// <remarks>
+    /// Bit set = require confirmation, bit clear = do not require confirmation.
+    /// </remarks>
+    RequireConfirmation = (byte)Bits.Bit00,
+
+    /// <summary>
+    /// Determines which cipher key index to use when decrypting BUFFER BLOCK payload.
+    /// </summary>
+    /// <remarks>
+    /// Bit set = use odd KEY INDEX, bit clear = use even KEY INDEX.
+    /// </remarks>
+    KeyIndex = (byte)Bits.Bit02,
+
+    /// <summary>
+    /// Determines if BUFFER BLOCK payload is compressed.
+    /// </summary>
+    /// <remarks>
+    /// Bit set = payload compressed (per the algorithm negotiated for buffer-block payloads,
+    /// default GZip per IEEE Std 2664-2024 Annex), bit clear = payload uncompressed.
+    /// </remarks>
+    Compressed = (byte)Bits.Bit03,
+
+    /// <summary>
+    /// Determines which Signal Index Cache index to use when decoding the BUFFER BLOCK payload.
+    /// </summary>
+    /// <remarks>
+    /// Bit set = use odd CACHE INDEX, bit clear = use even CACHE INDEX.
+    /// </remarks>
+    CacheIndex = (byte)Bits.Bit04
+}
+
+/// <summary>
 /// Operational modes that affect how <see cref="DataPublisher"/> and <see cref="DataSubscriber"/> communicate.
 /// </summary>
 /// <remarks>

--- a/src/lib/sttp.core/DataSubscriber.cs
+++ b/src/lib/sttp.core/DataSubscriber.cs
@@ -480,11 +480,11 @@ public class DataSubscriber : InputAdapterBase
         // Default to not using transactions for meta-data on SQL server (helps avoid deadlocks)
         try
         {
-#if NET
+        #if NET
             using AdoDataConnection database = new(ConfigSettings.Instance);
-#else
+        #else
             using AdoDataConnection database = new("systemSettings");
-#endif
+        #endif
             UseTransactionForMetadata = database.DatabaseType != DatabaseType.SQLServer;
         }
         catch
@@ -550,7 +550,7 @@ public class DataSubscriber : InputAdapterBase
     /// Gets flag that indicates whether the connection will be persisted
     /// even while the adapter is offline in order to synchronize metadata.
     /// </summary>
-    public bool PersistConnectionForMetadata =>
+    public bool PersistConnectionForMetadata => 
         !AutoStart && AutoSynchronizeMetadata && !this.TemporalConstraintIsDefined();
 
     /// <summary>
@@ -945,11 +945,11 @@ public class DataSubscriber : InputAdapterBase
         set
         {
             base.DataSource = value;
-#if NET
+        #if NET
             m_registerStatisticsOperation.RunAsync();
-#else
+        #else
             m_registerStatisticsOperation.RunOnce();
-#endif
+        #endif
 
             bool outputMeasurementsUpdated = AutoConnect && UpdateOutputMeasurements();
 
@@ -1096,9 +1096,9 @@ public class DataSubscriber : InputAdapterBase
                 status.AppendLine("----------------------".CenterText(50));
                 status.Append(m_clientCommandChannel.Status);
 
-#if !NET
+            #if !NET
                 status.AppendLine($"   Using simple TCP client: {UseSimpleTcpClient}");
-#endif
+            #endif
             }
 
             if (m_serverCommandChannel is not null)
@@ -1435,9 +1435,9 @@ public class DataSubscriber : InputAdapterBase
             AutoEnableSyncedDevices = !SyncIndependentDevices;
 
         // Check if user wants to request that publisher use millisecond resolution to conserve bandwidth
-#pragma warning disable CS0618 // Type or member is obsolete
+    #pragma warning disable CS0618 // Type or member is obsolete
         UseMillisecondResolution = !settings.TryGetValue(nameof(UseMillisecondResolution), out setting) || setting.ParseBoolean();
-#pragma warning restore CS0618
+    #pragma warning restore CS0618
 
         // Check if user has defined any meta-data filter expressions
         if (settings.TryGetValue(nameof(MetadataFilters), out setting))
@@ -1512,10 +1512,10 @@ public class DataSubscriber : InputAdapterBase
 
         bool serverBasedConnection = !commandChannelSettings.TryGetValue("server", out string? server) || string.IsNullOrWhiteSpace(server);
 
-#if !NET
+    #if !NET
         if (settings.TryGetValue(nameof(UseSimpleTcpClient), out setting))
             UseSimpleTcpClient = setting.ParseBoolean();
-#endif
+    #endif
 
         if (securityMode == SecurityMode.TLS)
         {
@@ -1562,9 +1562,9 @@ public class DataSubscriber : InputAdapterBase
                     ReceiveBufferSize = bufferSize,
                     SendBufferSize = bufferSize,
                     NoDelay = true,
-#if !NET
+                #if !NET
                     PersistSettings = false,
-#endif
+                #endif
                 };
 
                 // Assign command channel server reference and attach to needed events
@@ -1586,9 +1586,9 @@ public class DataSubscriber : InputAdapterBase
                     ReceiveBufferSize = bufferSize,
                     SendBufferSize = bufferSize,
                     NoDelay = true,
-#if !NET
+                #if !NET
                     PersistSettings = false,
-#endif
+                #endif
                 };
 
                 // Assign command channel client reference and attach to needed events
@@ -1610,9 +1610,9 @@ public class DataSubscriber : InputAdapterBase
                     ReceiveBufferSize = bufferSize,
                     SendBufferSize = bufferSize,
                     NoDelay = true,
-#if !NET
+                #if !NET
                     PersistSettings = false,
-#endif
+                #endif
                 };
 
                 // Assign command channel server reference and attach to needed events
@@ -1620,7 +1620,7 @@ public class DataSubscriber : InputAdapterBase
             }
             else
             {
-#if !NET
+            #if !NET
                 if (UseSimpleTcpClient)
                 {
                     // Create a new simple TCP client
@@ -1642,28 +1642,28 @@ public class DataSubscriber : InputAdapterBase
                 }
                 else
                 {
-#endif
-                // Create a new TCP client
-                TcpClient commandChannel = new()
-                {
-                    ConnectionString = commandChannelConnectionString,
-                    PayloadAware = true,
-                    PayloadMarker = null,
-                    PayloadEndianOrder = EndianOrder.BigEndian,
-                    MaxConnectionAttempts = 1,
-                    ReceiveBufferSize = bufferSize,
-                    SendBufferSize = bufferSize,
-                    NoDelay = true,
-#if !NET
-                    PersistSettings = false,
-#endif
-                };
+                #endif
+                    // Create a new TCP client
+                    TcpClient commandChannel = new()
+                    {
+                        ConnectionString = commandChannelConnectionString,
+                        PayloadAware = true,
+                        PayloadMarker = null,
+                        PayloadEndianOrder = EndianOrder.BigEndian,
+                        MaxConnectionAttempts = 1,
+                        ReceiveBufferSize = bufferSize,
+                        SendBufferSize = bufferSize,
+                        NoDelay = true,
+                    #if !NET
+                        PersistSettings = false,
+                    #endif
+                    };
 
-                // Assign command channel client reference and attach to needed events
-                ClientCommandChannel = commandChannel;
-#if !NET
+                    // Assign command channel client reference and attach to needed events
+                    ClientCommandChannel = commandChannel;
+                #if !NET
                 }
-#endif
+            #endif
             }
         }
 
@@ -1702,16 +1702,16 @@ public class DataSubscriber : InputAdapterBase
             else
             {
                 // Make sure setting exists to allow user to by-pass data gap recovery at a configuration level
-#if NET
+            #if NET
                 SettingsSection systemSettings = ConfigSettings.Instance[ConfigSettings.SystemSettingsCategory];
                 object? dataGapRecoveryEnabledSetting = systemSettings["DataGapRecoveryEnabled"];
                 bool dataGapRecoveryEnabled = (dataGapRecoveryEnabledSetting?.ToString() ?? "false").ParseBoolean();
-#else
+            #else
                 ConfigurationFile configFile = ConfigurationFile.Current;
                 CategorizedSettingsElementCollection systemSettings = configFile.Settings["systemSettings"];
                 CategorizedSettingsElement dataGapRecoveryEnabledSetting = systemSettings["DataGapRecoveryEnabled"];
                 bool dataGapRecoveryEnabled = dataGapRecoveryEnabledSetting is not null && dataGapRecoveryEnabledSetting.ValueAsBoolean();
-#endif
+            #endif
 
                 // See if this node should process phasor source validation
                 if (dataGapRecoveryEnabled)
@@ -1804,9 +1804,9 @@ public class DataSubscriber : InputAdapterBase
             if (Settings.TryGetValue("outputMeasurements", out string? setting))
                 OutputMeasurements = ParseOutputMeasurements(DataSource, true, setting);
 
-#pragma warning disable CA2245
+        #pragma warning disable CA2245
             OutputSourceIDs = OutputSourceIDs;
-#pragma warning restore CA2245
+        #pragma warning restore CA2245
         }
 
         // If active measurements are defined, attempt to defined desired subscription points from there
@@ -1913,11 +1913,11 @@ public class DataSubscriber : InputAdapterBase
         connectionString.Append($"requestNaNValueFilter={info.RequestNaNValueFilter};");
 
         Version version = assemblyInfo.Version ?? new Version(0, 0, 0);
-#if NET
+    #if NET
         const string SourceLib = nameof(Gemstone);
-#else
+    #else
         const string SourceLib = nameof(GSF);
-#endif
+    #endif
         connectionString.Append($"assemblyInfo={{source=STTP {SourceLib} Library ({assemblyInfo.Name}.dll); version={version.Major}.{version.Minor}.{version.Build}; updatedOn={assemblyInfo.BuildDate:yyyy-MM-dd HH:mm:ss} }};");
 
         if (!string.IsNullOrWhiteSpace(info.FilterExpression))
@@ -1944,9 +1944,9 @@ public class DataSubscriber : InputAdapterBase
             m_dataStreamMonitor.Interval = (int)(2.0D * info.LagTime * 1000.0D);
 
         // Set millisecond resolution member variable for compact measurement parsing
-#pragma warning disable 618
+    #pragma warning disable 618
         UseMillisecondResolution = info.UseMillisecondResolution;
-#pragma warning restore 618
+    #pragma warning restore 618
 
         return Subscribe(info.UseCompactMeasurementFormat, connectionString.ToString());
     }
@@ -2025,9 +2025,9 @@ public class DataSubscriber : InputAdapterBase
 
             if (settings.TryGetValue("port", out string? setting) || settings.TryGetValue("localPort", out setting))
             {
-#pragma warning disable CA1806
+            #pragma warning disable CA1806
                 int.TryParse(setting, out port);
-#pragma warning restore CA1806
+            #pragma warning restore CA1806
             }
         }
 
@@ -2221,8 +2221,8 @@ public class DataSubscriber : InputAdapterBase
         string startTime = split[0];
         string endTime = split[1];
 
-        bool parserSuccessful =
-            DateTimeOffset.TryParse(startTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out DateTimeOffset start) &&
+        bool parserSuccessful = 
+            DateTimeOffset.TryParse(startTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out DateTimeOffset start) && 
             DateTimeOffset.TryParse(endTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out end);
 
         if (!parserSuccessful)
@@ -2253,7 +2253,7 @@ public class DataSubscriber : InputAdapterBase
         string endTime = split[1];
 
         bool parserSuccessful =
-            DateTimeOffset.TryParse(startTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out DateTimeOffset start) &&
+            DateTimeOffset.TryParse(startTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out DateTimeOffset start) && 
             DateTimeOffset.TryParse(endTime, CultureInfo.CurrentCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AllowInnerWhite, out end);
 
         if (!parserSuccessful)
@@ -2305,11 +2305,11 @@ public class DataSubscriber : InputAdapterBase
         try
         {
             m_receivedMetadata = metadata;
-#if NET
+        #if NET
             m_synchronizeMetadataOperation.RunAsync();
-#else
+        #else
             m_synchronizeMetadataOperation.RunOnceAsync();
-#endif
+        #endif
         }
         catch (Exception ex)
         {
@@ -2387,11 +2387,11 @@ public class DataSubscriber : InputAdapterBase
         long now = UseLocalClockAsRealTime ? DateTime.UtcNow.Ticks : 0L;
         List<DeviceStatisticsHelper<SubscribedDevice>>? statisticsHelpers = m_statisticsHelpers;
 
-#if NET
+    #if NET
         m_registerStatisticsOperation.RunAsync();
-#else
+    #else
         m_registerStatisticsOperation.RunOnceAsync();
-#endif
+    #endif
         m_expectedBufferBlockSequenceNumber = 0u;
         m_commandChannelConnectionAttempts = 0;
         m_dataChannelConnectionAttempts = 0;
@@ -2419,7 +2419,7 @@ public class DataSubscriber : InputAdapterBase
         if (UseLocalClockAsRealTime && m_subscribedDevicesTimer is null)
         {
             m_subscribedDevicesTimer = Common.TimerScheduler.CreateTimer(1000);
-            m_subscribedDevicesTimer.Elapsed += SubscribedDevicesTimer_Elapsed;
+            m_subscribedDevicesTimer!.Elapsed += SubscribedDevicesTimer_Elapsed;
         }
 
         if (statisticsHelpers is not null)
@@ -2441,11 +2441,11 @@ public class DataSubscriber : InputAdapterBase
     protected override void AttemptDisconnection()
     {
         // Unregister device statistics
-#if NET
+    #if NET
         m_registerStatisticsOperation.RunAsync();
-#else
+    #else
         m_registerStatisticsOperation.RunOnceAsync();
-#endif
+    #endif
 
         // Stop data stream monitor
         if (m_dataStreamMonitor is not null)
@@ -2570,284 +2570,284 @@ public class DataSubscriber : InputAdapterBase
                             m_metadataRefreshPending = false;
                         break;
                     case ServerResponse.DataPacket:
+                    {
+                        long now = DateTime.UtcNow.Ticks;
+
+                        // Deserialize data packet
+                        List<IMeasurement> measurements = [];
+                        Ticks timestamp = default;
+
+                        if (TotalBytesReceived == 0)
                         {
-                            long now = DateTime.UtcNow.Ticks;
+                            // At the point when data is being received, data monitor should be enabled
+                            if (m_dataStreamMonitor is not null && m_dataStreamMonitor.Enabled)
+                                m_dataStreamMonitor.Enabled = true;
 
-                            // Deserialize data packet
-                            List<IMeasurement> measurements = [];
-                            Ticks timestamp = default;
-
-                            if (TotalBytesReceived == 0)
+                            // Establish run-time log for subscriber
+                            if (AutoConnect || m_dataGapRecoveryEnabled)
                             {
-                                // At the point when data is being received, data monitor should be enabled
-                                if (m_dataStreamMonitor is not null && m_dataStreamMonitor.Enabled)
-                                    m_dataStreamMonitor.Enabled = true;
-
-                                // Establish run-time log for subscriber
-                                if (AutoConnect || m_dataGapRecoveryEnabled)
+                                if (m_runTimeLog is null)
                                 {
-                                    if (m_runTimeLog is null)
-                                    {
-                                        m_runTimeLog = new RunTimeLog { FileName = GetLoggingPath($"{Name}_RunTimeLog.txt") };
-                                        m_runTimeLog.ProcessException += RunTimeLog_ProcessException;
-                                        m_runTimeLog.Initialize();
-                                    }
-                                    else
-                                    {
-                                        // Mark the start of any data transmissions
-                                        m_runTimeLog.StartTime = DateTimeOffset.UtcNow;
-                                        m_runTimeLog.Enabled = true;
-                                    }
-                                }
-
-                                // The duration between last disconnection and start of data transmissions
-                                // represents a gap in data - if data gap recovery is enabled, we log
-                                // this as a gap for recovery:
-                                if (m_dataGapRecoveryEnabled)
-                                    m_dataGapRecoverer?.LogDataGap(m_runTimeLog!.StopTime, DateTimeOffset.UtcNow);
-                            }
-
-                            // Track total data packet bytes received from any channel
-                            TotalBytesReceived += m_lastBytesReceived;
-                            m_monitoredBytesReceived += m_lastBytesReceived;
-
-                            // Get data packet flags
-                            DataPacketFlags flags = (DataPacketFlags)buffer[responseIndex];
-                            responseIndex++;
-
-                            SignalIndexCache? signalIndexCache;
-                            bool compactMeasurementFormat = (byte)(flags & DataPacketFlags.Compact) > 0;
-                            bool compressedPayload = (byte)(flags & DataPacketFlags.Compressed) > 0;
-                            int cipherIndex = (flags & DataPacketFlags.CipherIndex) > 0 ? 1 : 0;
-                            int cacheIndex = (flags & DataPacketFlags.CacheIndex) > 0 ? 1 : 0;
-                            byte[] packet = buffer;
-                            int packetLength = responseLength - 1;
-
-                            lock (m_signalIndexCacheLock)
-                                signalIndexCache = m_signalIndexCache?[cacheIndex];
-
-                            // Decrypt data packet payload if keys are available
-                            if (m_keyIVs is not null)
-                            {
-                                // Get a local copy of volatile keyIVs reference since this can change at any time
-                                keyIVs = m_keyIVs;
-
-                                // Decrypt payload portion of data packet
-                                packet = Common.SymmetricAlgorithm.Decrypt(packet, responseIndex, packetLength, keyIVs[cipherIndex][0], keyIVs[cipherIndex][1]);
-                                responseIndex = 0;
-                                packetLength = packet.Length;
-                            }
-
-                            // Deserialize number of measurements that follow
-                            int count = BigEndian.ToInt32(packet, responseIndex);
-                            responseIndex += 4;
-                            packetLength -= 4;
-
-                            if (compressedPayload)
-                            {
-                                if (CompressionModes.HasFlag(CompressionModes.TSSC))
-                                {
-                                    if (signalIndexCache is not null)
-                                    {
-                                        try
-                                        {
-                                            // Decompress TSSC serialized measurements from payload
-                                            ParseTSSCMeasurements(packet, packetLength, signalIndexCache, ref responseIndex, measurements);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            OnProcessException(MessageLevel.Error, new InvalidOperationException($"Decompression failure: (Decoded {measurements.Count} of {count} measurements) - {ex.Message}", ex));
-                                        }
-                                    }
+                                    m_runTimeLog = new RunTimeLog { FileName = GetLoggingPath($"{Name}_RunTimeLog.txt") };
+                                    m_runTimeLog.ProcessException += RunTimeLog_ProcessException;
+                                    m_runTimeLog.Initialize();
                                 }
                                 else
                                 {
-                                    OnProcessException(MessageLevel.Error, new InvalidOperationException("Decompression failure: Unexpected compression type in use - STTP currently only supports TSSC payload compression"));
+                                    // Mark the start of any data transmissions
+                                    m_runTimeLog.StartTime = DateTimeOffset.UtcNow;
+                                    m_runTimeLog.Enabled = true;
+                                }
+                            }
+
+                            // The duration between last disconnection and start of data transmissions
+                            // represents a gap in data - if data gap recovery is enabled, we log
+                            // this as a gap for recovery:
+                            if (m_dataGapRecoveryEnabled)
+                                m_dataGapRecoverer?.LogDataGap(m_runTimeLog!.StopTime, DateTimeOffset.UtcNow);
+                        }
+
+                        // Track total data packet bytes received from any channel
+                        TotalBytesReceived += m_lastBytesReceived;
+                        m_monitoredBytesReceived += m_lastBytesReceived;
+
+                        // Get data packet flags
+                        DataPacketFlags flags = (DataPacketFlags)buffer[responseIndex];
+                        responseIndex++;
+
+                        SignalIndexCache? signalIndexCache;
+                        bool compactMeasurementFormat = (byte)(flags & DataPacketFlags.Compact) > 0;
+                        bool compressedPayload = (byte)(flags & DataPacketFlags.Compressed) > 0;
+                        int cipherIndex = (flags & DataPacketFlags.CipherIndex) > 0 ? 1 : 0;
+                        int cacheIndex = (flags & DataPacketFlags.CacheIndex) > 0 ? 1 : 0;
+                        byte[] packet = buffer;
+                        int packetLength = responseLength - 1;
+
+                        lock (m_signalIndexCacheLock)
+                            signalIndexCache = m_signalIndexCache?[cacheIndex];
+
+                        // Decrypt data packet payload if keys are available
+                        if (m_keyIVs is not null)
+                        {
+                            // Get a local copy of volatile keyIVs reference since this can change at any time
+                            keyIVs = m_keyIVs;
+
+                            // Decrypt payload portion of data packet
+                            packet = Common.SymmetricAlgorithm.Decrypt(packet, responseIndex, packetLength, keyIVs[cipherIndex][0], keyIVs[cipherIndex][1]);
+                            responseIndex = 0;
+                            packetLength = packet.Length;
+                        }
+
+                        // Deserialize number of measurements that follow
+                        int count = BigEndian.ToInt32(packet, responseIndex);
+                        responseIndex += 4;
+                        packetLength -= 4;
+
+                        if (compressedPayload)
+                        {
+                            if (CompressionModes.HasFlag(CompressionModes.TSSC))
+                            {
+                                if (signalIndexCache is not null)
+                                {
+                                    try
+                                    {
+                                        // Decompress TSSC serialized measurements from payload
+                                        ParseTSSCMeasurements(packet, packetLength, signalIndexCache, ref responseIndex, measurements);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        OnProcessException(MessageLevel.Error, new InvalidOperationException($"Decompression failure: (Decoded {measurements.Count} of {count} measurements) - {ex.Message}", ex));
+                                    }
                                 }
                             }
                             else
                             {
-                                // Deserialize measurements
-                                for (int i = 0; i < count; i++)
+                                OnProcessException(MessageLevel.Error, new InvalidOperationException("Decompression failure: Unexpected compression type in use - STTP currently only supports TSSC payload compression"));
+                            }
+                        }
+                        else
+                        {
+                            // Deserialize measurements
+                            for (int i = 0; i < count; i++)
+                            {
+                                if (!compactMeasurementFormat)
                                 {
-                                    if (!compactMeasurementFormat)
-                                    {
-#if NET
+                                #if NET
                                         throw new NotSupportedException("Full measurement format not supported in Gemstone STTP implementation");
-#else
+                                #else
                                     // Deserialize full measurement format
                                     SerializableMeasurement measurement = new(Encoding);
                                     responseIndex += measurement.ParseBinaryImage(packet, responseIndex, length - responseIndex);
                                     measurements.Add(measurement);
-#endif
-                                    }
-                                    // ReSharper disable once RedundantIfElseBlock
-                                    else if (signalIndexCache is not null)
-                                    {
-#pragma warning disable 618
-                                        bool useMillisecondResolution = UseMillisecondResolution;
-#pragma warning restore 618
+                                #endif
+                                }
+                                // ReSharper disable once RedundantIfElseBlock
+                                else if (signalIndexCache is not null)
+                                {
+                                #pragma warning disable 618
+                                    bool useMillisecondResolution = UseMillisecondResolution;
+                                #pragma warning restore 618
 
-                                        // Deserialize compact measurement format
-                                        CompactMeasurement measurement = new(signalIndexCache, m_includeTime, m_baseTimeOffsets, m_timeIndex, useMillisecondResolution);
-                                        responseIndex += measurement.ParseBinaryImage(packet, responseIndex, length - responseIndex);
+                                    // Deserialize compact measurement format
+                                    CompactMeasurement measurement = new(signalIndexCache, m_includeTime, m_baseTimeOffsets, m_timeIndex, useMillisecondResolution);
+                                    responseIndex += measurement.ParseBinaryImage(packet, responseIndex, length - responseIndex);
 
-                                        // Apply timestamp from frame if not included in transmission
-                                        if (!measurement.IncludeTime)
-                                            measurement.Timestamp = timestamp;
+                                    // Apply timestamp from frame if not included in transmission
+                                    if (!measurement.IncludeTime)
+                                        measurement.Timestamp = timestamp;
 
-                                        measurements.Add(measurement);
-                                    }
-                                    else if (m_lastMissingCacheWarning + MissingCacheWarningInterval < now)
-                                    {
-                                        // Warning message for missing signal index cache
-                                        if (m_lastMissingCacheWarning != 0L)
-                                            OnStatusMessage(MessageLevel.Error, "Signal index cache has not arrived. No compact measurements can be parsed.");
+                                    measurements.Add(measurement);
+                                }
+                                else if (m_lastMissingCacheWarning + MissingCacheWarningInterval < now)
+                                {
+                                    // Warning message for missing signal index cache
+                                    if (m_lastMissingCacheWarning != 0L)
+                                        OnStatusMessage(MessageLevel.Error, "Signal index cache has not arrived. No compact measurements can be parsed.");
 
-                                        m_lastMissingCacheWarning = now;
-                                    }
+                                    m_lastMissingCacheWarning = now;
                                 }
                             }
+                        }
 
-                            // Calculate statistics
-                            subscribedDevicesLookup = m_subscribedDevicesLookup;
-                            statisticsHelper = null;
+                        // Calculate statistics
+                        subscribedDevicesLookup = m_subscribedDevicesLookup;
+                        statisticsHelper = null;
 
-                            if (subscribedDevicesLookup is not null)
+                        if (subscribedDevicesLookup is not null)
+                        {
+                            IEnumerable<IGrouping<DeviceStatisticsHelper<SubscribedDevice>?, IMeasurement>> deviceGroups = measurements
+                                .Where(measurement => subscribedDevicesLookup.TryGetValue(measurement.ID, out statisticsHelper))
+                                .Select(measurement => Tuple.Create(statisticsHelper, measurement))
+                                .ToList()
+                                .GroupBy(tuple => tuple.Item1, tuple => tuple.Item2);
+
+                            foreach (IGrouping<DeviceStatisticsHelper<SubscribedDevice>?, IMeasurement> deviceGroup in deviceGroups)
                             {
-                                IEnumerable<IGrouping<DeviceStatisticsHelper<SubscribedDevice>?, IMeasurement>> deviceGroups = measurements
-                                    .Where(measurement => subscribedDevicesLookup.TryGetValue(measurement.ID, out statisticsHelper))
-                                    .Select(measurement => Tuple.Create(statisticsHelper, measurement))
-                                    .ToList()
-                                    .GroupBy(tuple => tuple.Item1, tuple => tuple.Item2);
+                                statisticsHelper = deviceGroup.Key;
 
-                                foreach (IGrouping<DeviceStatisticsHelper<SubscribedDevice>?, IMeasurement> deviceGroup in deviceGroups)
+                                foreach (IGrouping<Ticks, IMeasurement> frame in deviceGroup.GroupBy(measurement => measurement.Timestamp))
                                 {
-                                    statisticsHelper = deviceGroup.Key;
+                                    // Determine the number of measurements received with valid values
+                                    const MeasurementStateFlags ErrorFlags = MeasurementStateFlags.BadData | MeasurementStateFlags.BadTime | MeasurementStateFlags.SystemError;
 
-                                    foreach (IGrouping<Ticks, IMeasurement> frame in deviceGroup.GroupBy(measurement => measurement.Timestamp))
+                                    static bool hasError(MeasurementStateFlags stateFlags)
                                     {
-                                        // Determine the number of measurements received with valid values
-                                        const MeasurementStateFlags ErrorFlags = MeasurementStateFlags.BadData | MeasurementStateFlags.BadTime | MeasurementStateFlags.SystemError;
+                                        return (stateFlags & ErrorFlags) != MeasurementStateFlags.Normal;
+                                    }
 
-                                        static bool hasError(MeasurementStateFlags stateFlags)
+                                    int measurementsReceived = frame.Count(measurement => !double.IsNaN(measurement.Value));
+                                    int measurementsWithError = frame.Count(measurement => !double.IsNaN(measurement.Value) && hasError(measurement.StateFlags));
+
+                                    IMeasurement? statusFlags = null;
+                                    IMeasurement? frequency = null;
+                                    IMeasurement? deltaFrequency = null;
+
+                                    // Attempt to update real-time
+                                    if (!UseLocalClockAsRealTime && frame.Key > m_realTime)
+                                        m_realTime = frame.Key;
+
+                                    // Search the frame for status flags, frequency, and delta frequency
+                                    foreach (IMeasurement measurement in frame)
+                                    {
+                                        if (measurement.ID == statisticsHelper?.Device.StatusFlagsID)
+                                            statusFlags = measurement;
+                                        else if (measurement.ID == statisticsHelper?.Device.FrequencyID)
+                                            frequency = measurement;
+                                        else if (measurement.ID == statisticsHelper?.Device.DeltaFrequencyID)
+                                            deltaFrequency = measurement;
+                                    }
+
+                                    // If we are receiving status flags for this device,
+                                    // count the data quality, time quality, and device errors
+                                    if (statusFlags is not null)
+                                    {
+                                        if (statisticsHelper is not null)
                                         {
-                                            return (stateFlags & ErrorFlags) != MeasurementStateFlags.Normal;
+                                            uint commonStatusFlags = (uint)statusFlags.Value;
+
+                                            if ((commonStatusFlags & (uint)Bits.Bit19) > 0)
+                                                statisticsHelper.Device.DataQualityErrors++;
+
+                                            if ((commonStatusFlags & (uint)Bits.Bit18) > 0)
+                                                statisticsHelper.Device.TimeQualityErrors++;
+
+                                            if ((commonStatusFlags & (uint)Bits.Bit16) > 0)
+                                                statisticsHelper.Device.DeviceErrors++;
                                         }
 
-                                        int measurementsReceived = frame.Count(measurement => !double.IsNaN(measurement.Value));
-                                        int measurementsWithError = frame.Count(measurement => !double.IsNaN(measurement.Value) && hasError(measurement.StateFlags));
+                                        measurementsReceived--;
 
-                                        IMeasurement? statusFlags = null;
-                                        IMeasurement? frequency = null;
-                                        IMeasurement? deltaFrequency = null;
+                                        if (hasError(statusFlags.StateFlags))
+                                            measurementsWithError--;
+                                    }
 
-                                        // Attempt to update real-time
-                                        if (!UseLocalClockAsRealTime && frame.Key > m_realTime)
-                                            m_realTime = frame.Key;
+                                    // Zero is not a valid value for frequency.
+                                    // If frequency is zero, invalidate both frequency and delta frequency
+                                    if (frequency is not null)
+                                    {
+                                        if (!this.TemporalConstraintIsDefined())
+                                            statisticsHelper?.MarkDeviceTimestamp(frequency.Timestamp);
 
-                                        // Search the frame for status flags, frequency, and delta frequency
-                                        foreach (IMeasurement measurement in frame)
+                                        if (frequency.Value == 0.0D)
                                         {
-                                            if (measurement.ID == statisticsHelper?.Device.StatusFlagsID)
-                                                statusFlags = measurement;
-                                            else if (measurement.ID == statisticsHelper?.Device.FrequencyID)
-                                                frequency = measurement;
-                                            else if (measurement.ID == statisticsHelper?.Device.DeltaFrequencyID)
-                                                deltaFrequency = measurement;
-                                        }
+                                            if (deltaFrequency is null || double.IsNaN(deltaFrequency.Value))
+                                                measurementsReceived--;
+                                            else
+                                                measurementsReceived -= 2;
 
-                                        // If we are receiving status flags for this device,
-                                        // count the data quality, time quality, and device errors
-                                        if (statusFlags is not null)
-                                        {
-                                            if (statisticsHelper is not null)
-                                            {
-                                                uint commonStatusFlags = (uint)statusFlags.Value;
-
-                                                if ((commonStatusFlags & (uint)Bits.Bit19) > 0)
-                                                    statisticsHelper.Device.DataQualityErrors++;
-
-                                                if ((commonStatusFlags & (uint)Bits.Bit18) > 0)
-                                                    statisticsHelper.Device.TimeQualityErrors++;
-
-                                                if ((commonStatusFlags & (uint)Bits.Bit16) > 0)
-                                                    statisticsHelper.Device.DeviceErrors++;
-                                            }
-
-                                            measurementsReceived--;
-
-                                            if (hasError(statusFlags.StateFlags))
-                                                measurementsWithError--;
-                                        }
-
-                                        // Zero is not a valid value for frequency.
-                                        // If frequency is zero, invalidate both frequency and delta frequency
-                                        if (frequency is not null)
-                                        {
-                                            if (!this.TemporalConstraintIsDefined())
-                                                statisticsHelper?.MarkDeviceTimestamp(frequency.Timestamp);
-
-                                            if (frequency.Value == 0.0D)
+                                            if (hasError(frequency.StateFlags))
                                             {
                                                 if (deltaFrequency is null || double.IsNaN(deltaFrequency.Value))
-                                                    measurementsReceived--;
+                                                    measurementsWithError--;
                                                 else
-                                                    measurementsReceived -= 2;
-
-                                                if (hasError(frequency.StateFlags))
-                                                {
-                                                    if (deltaFrequency is null || double.IsNaN(deltaFrequency.Value))
-                                                        measurementsWithError--;
-                                                    else
-                                                        measurementsWithError -= 2;
-                                                }
+                                                    measurementsWithError -= 2;
                                             }
                                         }
-
-                                        // Track the number of measurements received
-                                        statisticsHelper?.AddToMeasurementsReceived(measurementsReceived);
-                                        statisticsHelper?.AddToMeasurementsWithError(measurementsWithError);
                                     }
+
+                                    // Track the number of measurements received
+                                    statisticsHelper?.AddToMeasurementsReceived(measurementsReceived);
+                                    statisticsHelper?.AddToMeasurementsWithError(measurementsWithError);
                                 }
                             }
-
-                            OnNewMeasurements(measurements);
-
-                            // Gather statistics on received data
-                            DateTime timeReceived = RealTime;
-
-                            if (!UseLocalClockAsRealTime && timeReceived.Ticks - m_lastStatisticsHelperUpdate > Ticks.PerSecond)
-                            {
-                                UpdateStatisticsHelpers();
-                                m_lastStatisticsHelperUpdate = m_realTime;
-                            }
-
-                            LifetimeMeasurements += measurements.Count;
-                            UpdateMeasurementsPerSecond(timeReceived, measurements.Count);
-
-                            foreach (IMeasurement measurement in measurements)
-                            {
-                                long latency = timeReceived.Ticks - (long)measurement.Timestamp;
-
-                                // Throw out latencies that exceed one hour as invalid
-                                if (Math.Abs(latency) > Time.SecondsPerHour * Ticks.PerSecond)
-                                    continue;
-
-                                if (m_lifetimeMinimumLatency > latency || m_lifetimeMinimumLatency == 0)
-                                    m_lifetimeMinimumLatency = latency;
-
-                                if (m_lifetimeMaximumLatency < latency || m_lifetimeMaximumLatency == 0)
-                                    m_lifetimeMaximumLatency = latency;
-
-                                m_lifetimeTotalLatency += latency;
-                                m_lifetimeLatencyMeasurements++;
-                            }
-
-                            break;
                         }
-                    case ServerResponse.BufferBlock:
+
+                        OnNewMeasurements(measurements);
+
+                        // Gather statistics on received data
+                        DateTime timeReceived = RealTime;
+
+                        if (!UseLocalClockAsRealTime && timeReceived.Ticks - m_lastStatisticsHelperUpdate > Ticks.PerSecond)
                         {
+                            UpdateStatisticsHelpers();
+                            m_lastStatisticsHelperUpdate = m_realTime;
+                        }
+
+                        LifetimeMeasurements += measurements.Count;
+                        UpdateMeasurementsPerSecond(timeReceived, measurements.Count);
+
+                        foreach (IMeasurement measurement in measurements)
+                        {
+                            long latency = timeReceived.Ticks - (long)measurement.Timestamp;
+
+                            // Throw out latencies that exceed one hour as invalid
+                            if (Math.Abs(latency) > Time.SecondsPerHour * Ticks.PerSecond)
+                                continue;
+
+                            if (m_lifetimeMinimumLatency > latency || m_lifetimeMinimumLatency == 0)
+                                m_lifetimeMinimumLatency = latency;
+
+                            if (m_lifetimeMaximumLatency < latency || m_lifetimeMaximumLatency == 0)
+                                m_lifetimeMaximumLatency = latency;
+
+                            m_lifetimeTotalLatency += latency;
+                            m_lifetimeLatencyMeasurements++;
+                        }
+
+                        break;
+                    }
+                    case ServerResponse.BufferBlock:
+                    {
                         // Buffer block received - wrap as a buffer block measurement and expose back to consumer.
                         //
                         // Wire layout (per IEEE Std 2664-2024 § 5.5.10 Figure 34 with SIGNAL INDEX per corrigendum)
@@ -2856,101 +2856,101 @@ public class DataSubscriber : InputAdapterBase
                         //   +5  int32   SIGNAL INDEX
                         //   +9  byte[]  payload (GZip-compressed when Compressed bit set)
                         uint sequenceNumber = BigEndian.ToUInt32(buffer, responseIndex);
-                            int bufferCacheIndex = (int)(sequenceNumber - m_expectedBufferBlockSequenceNumber);
-                            BufferBlockFlags bufferBlockFlags = (BufferBlockFlags)buffer[responseIndex + 4];
-                            int signalCacheIndex = bufferBlockFlags.HasFlag(BufferBlockFlags.CacheIndex) ? 1 : 0;
-                            bool payloadCompressed = bufferBlockFlags.HasFlag(BufferBlockFlags.Compressed);
+                        int bufferCacheIndex = (int)(sequenceNumber - m_expectedBufferBlockSequenceNumber);
+                        BufferBlockFlags bufferBlockFlags = (BufferBlockFlags)buffer[responseIndex + 4];
+                        int signalCacheIndex = bufferBlockFlags.HasFlag(BufferBlockFlags.CacheIndex) ? 1 : 0;
+                        bool payloadCompressed = bufferBlockFlags.HasFlag(BufferBlockFlags.Compressed);
 
-                            // Check if this buffer block has already been processed (e.g., mistaken retransmission due to timeout)
-                            if (bufferCacheIndex >= 0 && (bufferCacheIndex >= m_bufferBlockCache.Count || m_bufferBlockCache[bufferCacheIndex] is null))
+                        // Check if this buffer block has already been processed (e.g., mistaken retransmission due to timeout)
+                        if (bufferCacheIndex >= 0 && (bufferCacheIndex >= m_bufferBlockCache.Count || m_bufferBlockCache[bufferCacheIndex] is null))
+                        {
+                            // Send confirmation that buffer block is received
+                            SendServerCommand(ServerCommand.ConfirmBufferBlock, buffer.BlockCopy(responseIndex, 4));
+
+                            // Get measurement key from signal index cache
+                            int signalIndex = BigEndian.ToInt32(buffer, responseIndex + 5);
+
+                            SignalIndexCache? signalIndexCache;
+
+                            lock (m_signalIndexCacheLock)
+                                signalIndexCache = m_signalIndexCache?[signalCacheIndex];
+
+                            if (signalIndexCache is null || !signalIndexCache.Reference.TryGetValue(signalIndex, out MeasurementKey? measurementKey))
+                                throw new InvalidOperationException($"Failed to find associated signal identification for runtime ID {signalIndex}");
+
+                            // Decompress the payload if the publisher set the Compressed flag. GZip is the
+                            // always-available baseline per IEEE Std 2664-2024 Table 4 default.
+                            byte[] payloadBuffer;
+                            int payloadOffset;
+                            int payloadLength;
+
+                            if (payloadCompressed)
                             {
-                                // Send confirmation that buffer block is received
-                                SendServerCommand(ServerCommand.ConfirmBufferBlock, buffer.BlockCopy(responseIndex, 4));
+                                using MemoryStream compressedStream = new(buffer, responseIndex + 9, responseLength - 9, writable: false);
+                                using BlockAllocatedMemoryStream decompressedStream = new();
 
-                                // Get measurement key from signal index cache
-                                int signalIndex = BigEndian.ToInt32(buffer, responseIndex + 5);
+                                using (GZipStream inflater = new(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                                    inflater.CopyTo(decompressedStream);
 
-                                SignalIndexCache? signalIndexCache;
-
-                                lock (m_signalIndexCacheLock)
-                                    signalIndexCache = m_signalIndexCache?[signalCacheIndex];
-
-                                if (signalIndexCache is null || !signalIndexCache.Reference.TryGetValue(signalIndex, out MeasurementKey? measurementKey))
-                                    throw new InvalidOperationException($"Failed to find associated signal identification for runtime ID {signalIndex}");
-
-                                // Decompress the payload if the publisher set the Compressed flag. GZip is the
-                                // always-available baseline per IEEE Std 2664-2024 Table 4 default.
-                                byte[] payloadBuffer;
-                                int payloadOffset;
-                                int payloadLength;
-
-                                if (payloadCompressed)
-                                {
-                                    using MemoryStream compressedStream = new(buffer, responseIndex + 9, responseLength - 9, writable: false);
-                                    using BlockAllocatedMemoryStream decompressedStream = new();
-
-                                    using (GZipStream inflater = new(compressedStream, CompressionMode.Decompress, leaveOpen: true))
-                                        inflater.CopyTo(decompressedStream);
-
-                                    payloadBuffer = decompressedStream.ToArray();
-                                    payloadOffset = 0;
-                                    payloadLength = payloadBuffer.Length;
-                                }
-                                else
-                                {
-                                    payloadBuffer = buffer;
-                                    payloadOffset = responseIndex + 9;
-                                    payloadLength = responseLength - 9;
-                                }
-
-                                BufferBlockMeasurement bufferBlockMeasurement = new(payloadBuffer, payloadOffset, payloadLength)
-                                {
-                                    Metadata = measurementKey.Metadata
-                                };
-
-                                // Determine if this is the next buffer block in the sequence
-                                if (sequenceNumber == m_expectedBufferBlockSequenceNumber)
-                                {
-                                    List<IMeasurement> bufferBlockMeasurements = [];
-                                    int i;
-
-                                    // Add the buffer block measurement to the list of measurements to be published
-                                    bufferBlockMeasurements.Add(bufferBlockMeasurement);
-                                    m_expectedBufferBlockSequenceNumber++;
-
-                                    // Add cached buffer block measurements to the list of measurements to be published
-                                    for (i = 1; i < m_bufferBlockCache.Count; i++)
-                                    {
-                                        if (m_bufferBlockCache[i] is null)
-                                            break;
-
-                                        bufferBlockMeasurements.Add(m_bufferBlockCache[i]!);
-                                        m_expectedBufferBlockSequenceNumber++;
-                                    }
-
-                                    // Remove published measurements from the buffer block queue
-                                    if (m_bufferBlockCache.Count > 0)
-                                        m_bufferBlockCache.RemoveRange(0, i);
-
-                                    // Publish measurements
-                                    OnNewMeasurements(bufferBlockMeasurements);
-                                }
-                                else
-                                {
-                                    // Ensure that the list has at least as many
-                                    // elements as it needs to cache this measurement
-                                    for (int i = m_bufferBlockCache.Count; i <= bufferCacheIndex; i++)
-                                        m_bufferBlockCache.Add(null);
-
-                                    // Insert this buffer block into the proper location in the list
-                                    m_bufferBlockCache[bufferCacheIndex] = bufferBlockMeasurement;
-                                }
+                                payloadBuffer = decompressedStream.ToArray();
+                                payloadOffset = 0;
+                                payloadLength = payloadBuffer.Length;
+                            }
+                            else
+                            {
+                                payloadBuffer = buffer;
+                                payloadOffset = responseIndex + 9;
+                                payloadLength = responseLength - 9;
                             }
 
-                            LifetimeMeasurements += 1;
-                            UpdateMeasurementsPerSecond(DateTime.UtcNow, 1);
-                            break;
+                            BufferBlockMeasurement bufferBlockMeasurement = new(payloadBuffer, payloadOffset, payloadLength)
+                            {
+                                Metadata = measurementKey.Metadata
+                            };
+
+                            // Determine if this is the next buffer block in the sequence
+                            if (sequenceNumber == m_expectedBufferBlockSequenceNumber)
+                            {
+                                List<IMeasurement> bufferBlockMeasurements = [];
+                                int i;
+
+                                // Add the buffer block measurement to the list of measurements to be published
+                                bufferBlockMeasurements.Add(bufferBlockMeasurement);
+                                m_expectedBufferBlockSequenceNumber++;
+
+                                // Add cached buffer block measurements to the list of measurements to be published
+                                for (i = 1; i < m_bufferBlockCache.Count; i++)
+                                {
+                                    if (m_bufferBlockCache[i] is null)
+                                        break;
+
+                                    bufferBlockMeasurements.Add(m_bufferBlockCache[i]!);
+                                    m_expectedBufferBlockSequenceNumber++;
+                                }
+
+                                // Remove published measurements from the buffer block queue
+                                if (m_bufferBlockCache.Count > 0)
+                                    m_bufferBlockCache.RemoveRange(0, i);
+
+                                // Publish measurements
+                                OnNewMeasurements(bufferBlockMeasurements);
+                            }
+                            else
+                            {
+                                // Ensure that the list has at least as many
+                                // elements as it needs to cache this measurement
+                                for (int i = m_bufferBlockCache.Count; i <= bufferCacheIndex; i++)
+                                    m_bufferBlockCache.Add(null);
+
+                                // Insert this buffer block into the proper location in the list
+                                m_bufferBlockCache[bufferCacheIndex] = bufferBlockMeasurement;
+                            }
                         }
+
+                        LifetimeMeasurements += 1;
+                        UpdateMeasurementsPerSecond(DateTime.UtcNow, 1);
+                        break;
+                    }
                     case ServerResponse.DataStartTime:
                         // Raise data start time event
                         OnDataStartTime(BigEndian.ToInt64(buffer, responseIndex));
@@ -2960,33 +2960,33 @@ public class DataSubscriber : InputAdapterBase
                         OnProcessingComplete(InterpretResponseMessage(buffer, responseIndex, responseLength));
                         break;
                     case ServerResponse.UpdateSignalIndexCache:
+                    {
+                        int version = Version;
+                        int cacheIndex = 0;
+
+                        // Get active cache index
+                        if (version > 1)
+                            cacheIndex = buffer[responseIndex++];
+
+                        // Deserialize new signal index cache
+                        SignalIndexCache remoteSignalIndexCache = DeserializeSignalIndexCache(buffer.BlockCopy(responseIndex, responseLength));
+                        SignalIndexCache signalIndexCache = new(DataSource, remoteSignalIndexCache);
+
+                        lock (m_signalIndexCacheLock)
                         {
-                            int version = Version;
-                            int cacheIndex = 0;
+                            Interlocked.CompareExchange(ref m_signalIndexCache, new SignalIndexCache[version > 1 ? 2 : 1], null);
 
-                            // Get active cache index
-                            if (version > 1)
-                                cacheIndex = buffer[responseIndex++];
-
-                            // Deserialize new signal index cache
-                            SignalIndexCache remoteSignalIndexCache = DeserializeSignalIndexCache(buffer.BlockCopy(responseIndex, responseLength));
-                            SignalIndexCache signalIndexCache = new(DataSource, remoteSignalIndexCache);
-
-                            lock (m_signalIndexCacheLock)
-                            {
-                                Interlocked.CompareExchange(ref m_signalIndexCache, new SignalIndexCache[version > 1 ? 2 : 1], null);
-
-                                m_signalIndexCache[cacheIndex] = signalIndexCache;
-                                m_remoteSignalIndexCache = remoteSignalIndexCache;
-                                m_cacheIndex = cacheIndex;
-                            }
-
-                            if (version > 1)
-                                SendServerCommand(ServerCommand.ConfirmSignalIndexCache);
-
-                            FixExpectedMeasurementCounts();
-                            break;
+                            m_signalIndexCache[cacheIndex] = signalIndexCache;
+                            m_remoteSignalIndexCache = remoteSignalIndexCache;
+                            m_cacheIndex = cacheIndex;
                         }
+
+                        if (version > 1)
+                            SendServerCommand(ServerCommand.ConfirmSignalIndexCache);
+
+                        FixExpectedMeasurementCounts();
+                        break;
+                    }
                     case ServerResponse.UpdateBaseTimes:
                         // Get active time index
                         m_timeIndex = BigEndian.ToInt32(buffer, responseIndex);
@@ -3130,7 +3130,7 @@ public class DataSubscriber : InputAdapterBase
 
             Measurement measurement = new()
             {
-                Metadata = key.Metadata,
+                Metadata = key!.Metadata,
                 Timestamp = time,
                 StateFlags = (MeasurementStateFlags)quality,
                 Value = value
@@ -3180,9 +3180,9 @@ public class DataSubscriber : InputAdapterBase
             processingInterval = ProcessingInterval;
         }
 
-        MeasurementKey[]? outputMeasurementKeys = AutoStart
-            ? this.OutputMeasurementKeys()
-            : RequestedOutputMeasurementKeys;
+        MeasurementKey[]? outputMeasurementKeys = AutoStart ? 
+            this.OutputMeasurementKeys() : 
+            RequestedOutputMeasurementKeys;
 
         if (outputMeasurementKeys is not null && outputMeasurementKeys.Length > 0)
         {
@@ -3197,9 +3197,9 @@ public class DataSubscriber : InputAdapterBase
             }
 
             // Start unsynchronized subscription
-#pragma warning disable 618
+        #pragma warning disable 618
             return Subscribe(true, Throttled, filterExpression.ToString(), dataChannel, startTime: startTimeConstraint, stopTime: stopTimeConstraint, processingInterval: processingInterval, publishInterval: PublishInterval);
-#pragma warning restore 618
+        #pragma warning restore 618
         }
 
         Unsubscribe();
@@ -3250,17 +3250,17 @@ public class DataSubscriber : InputAdapterBase
             DateTime latestUpdateTime = DateTime.MinValue;
 
             // Open the configuration database using settings found in the config file
-#if NET
+        #if NET
             using (AdoDataConnection database = new(ConfigSettings.Default))
             using (DbCommand command = database.Connection.CreateCommand())
             {
                 DbTransaction? transaction = null;
-#else
+        #else
             using (AdoDataConnection database = new("systemSettings"))
             using (IDbCommand command = database.Connection.CreateCommand())
             {
                 IDbTransaction? transaction = null;
-#endif
+            #endif
                 if (UseTransactionForMetadata)
                     transaction = database.Connection.BeginTransaction(database.DefaultIsolationLevel);
 
@@ -3284,7 +3284,7 @@ public class DataSubscriber : InputAdapterBase
                     // Get any historian associated with the subscriber device
                     object? historianID = ExecuteScalar(command, $"SELECT HistorianID FROM Device WHERE ID = {parentID}");
 
-#if !NET
+                #if !NET
                     // Determine the active node ID - we cache this since this value won't change for the lifetime of this class
                     if (m_nodeID == Guid.Empty)
                         m_nodeID = Guid.Parse(ExecuteScalar(command, $"SELECT NodeID FROM IaonInputAdapter WHERE ID = {(int)ID}")?.ToString() ?? Guid.Empty.ToString());
@@ -3292,7 +3292,7 @@ public class DataSubscriber : InputAdapterBase
                     // Determine the protocol record auto-inc ID value for STTP - this value is also cached since it shouldn't change for the lifetime of this class
                     if (m_sttpProtocolID == 0)
                         m_sttpProtocolID = int.Parse(ExecuteScalar(command, "SELECT ID FROM Protocol WHERE Acronym='STTP'")?.ToString() ?? "0");
-#endif
+                #endif
 
                     // Ascertain total number of actions required for all meta-data synchronization so some level feed back can be provided on progress
                     InitSyncProgress(metadata.Tables.Cast<DataTable>().Select(dataTable => (long)dataTable.Rows.Count).Sum() + 3);
@@ -3312,8 +3312,7 @@ public class DataSubscriber : InputAdapterBase
                         // Define SQL statement to query if this device is already defined (this should always be based on the unique guid-based device ID)
                         string deviceExistsSql = database.ParameterizedQueryString("SELECT COUNT(*) FROM Device WHERE UniqueID = {0}", "uniqueID");
 
-#if NET
-                        //                                                                             0         1            2        3     4               5         6          7         8            9                 --              10        --
+                    #if NET
                         // Define SQL statement to insert new device record
                         string insertDeviceSql = database.ParameterizedQueryString("INSERT INTO Device(ParentID, HistorianID, Acronym, Name, OriginalSource, AccessID, Longitude, Latitude, ContactList, ConnectionString, IsConcentrator, Internal, Enabled) " +
                                                                                    "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, 0, {10}, " + (AutoEnableSyncedDevices ? "1" : "0") + ")",
@@ -3325,11 +3324,11 @@ public class DataSubscriber : InputAdapterBase
 
                         string updateDeviceWithConnectionStringSql = database.ParameterizedQueryString("UPDATE Device SET Acronym = {0}, Name = {1}, OriginalSource = {2}, HistorianID = {3}, AccessID = {4}, Longitude = {5}, Latitude = {6}, ContactList = {7}, ConnectionString = {8}, Internal = {9} WHERE UniqueID = {10}",
                             "acronym", "name", "originalSource", "historianID", "accessID", "longitude", "latitude", "contactList", "connectionString", "internal", "uniqueID");
-#else
+                    #else
                         // Define SQL statement to insert new device record
                         string insertDeviceSql = database.ParameterizedQueryString("INSERT INTO Device(NodeID, ParentID, HistorianID, Acronym, Name, ProtocolID, FramesPerSecond, OriginalSource, AccessID, Longitude, Latitude, ContactList, ConnectionString, IsConcentrator, Enabled) " +
                                                                                    "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}, {12}, 0, " + (AutoEnableSyncedDevices ? "1" : "0") + ")",
-                                                                                   "nodeID", "parentID", "historianID", "acronym", "name", "protocolID", "framesPerSecond", "originalSource", "accessID", "longitude", "latitude", "contactList", "connectionString");
+                            "nodeID", "parentID", "historianID", "acronym", "name", "protocolID", "framesPerSecond", "originalSource", "accessID", "longitude", "latitude", "contactList", "connectionString");
 
                         // Define SQL statement to update existing device record
                         string updateDeviceSql = database.ParameterizedQueryString("UPDATE Device SET Acronym = {0}, Name = {1}, OriginalSource = {2}, ProtocolID = {3}, FramesPerSecond = {4}, HistorianID = {5}, AccessID = {6}, Longitude = {7}, Latitude = {8}, ContactList = {9} WHERE UniqueID = {10}",
@@ -3337,7 +3336,7 @@ public class DataSubscriber : InputAdapterBase
 
                         string updateDeviceWithConnectionStringSql = database.ParameterizedQueryString("UPDATE Device SET Acronym = {0}, Name = {1}, OriginalSource = {2}, ProtocolID = {3}, FramesPerSecond = {4}, HistorianID = {5}, AccessID = {6}, Longitude = {7}, Latitude = {8}, ContactList = {9}, ConnectionString = {10} WHERE UniqueID = {11}",
                             "acronym", "name", "originalSource", "protocolID", "framesPerSecond", "historianID", "accessID", "longitude", "latitude", "contactList", "connectionString", "uniqueID");
-#endif
+                    #endif
 
                         // Define SQL statement to update device's guid-based unique ID after insert
                         string updateDeviceUniqueIDSql = database.ParameterizedQueryString("UPDATE Device SET UniqueID = {0} WHERE Acronym = {1}", "uniqueID", "acronym");
@@ -3389,11 +3388,10 @@ public class DataSubscriber : InputAdapterBase
                         if (uniqueIDs.Count > 0)
                         {
                             // ReSharper disable once AccessToDisposedClosure
-                            IEnumerable<Guid> retiredUniqueIDs =
-                                RetrieveData(database, command, queryUniqueDeviceIDsSql, parentIDValue)
-                                    .Select()
-                                    .Select(deviceRow => deviceRow.ConvertGuidField("UniqueID"))
-                                    .Except(uniqueIDs);
+                            IEnumerable<Guid> retiredUniqueIDs = RetrieveData(database, command, queryUniqueDeviceIDsSql, parentIDValue)
+                                .Select()
+                                .Select(deviceRow => deviceRow.ConvertGuidField("UniqueID"))
+                                .Except(uniqueIDs);
 
                             foreach (Guid retiredUniqueID in retiredUniqueIDs)
                                 ExecuteNonQuery(command, deleteDeviceSql, database.Guid(retiredUniqueID));
@@ -3480,19 +3478,19 @@ public class DataSubscriber : InputAdapterBase
                                 if (interconnectionNameFieldExists)
                                     contactList["interconnectionName"] = row.Field<string>("InterconnectionName") ?? string.Empty;
 
-#if !NET
+                            #if !NET
                                 int protocolID = m_sttpProtocolID;
-#endif
+                            #endif
 
                                 // If we are synchronizing independent devices, we need to determine the protocol ID for the device
                                 // based on the protocol name defined in the meta-data
                                 if (SyncIndependentDevices && !string.IsNullOrWhiteSpace(protocolName))
                                 {
-#if NET
+                                #if NET
                                     Dictionary<string, string> settings = connectionString.ParseKeyValuePairs();
                                     settings["phasorProtocol"] = protocolName;
                                     connectionString = settings.JoinKeyValuePairs();
-#else
+                                #else
                                     string queryProtocolIDSql = database.ParameterizedQueryString("SELECT ID FROM Protocol WHERE Name = {0}", "protocolName");
                                     object? protocolIDValue = ExecuteScalar(command, queryProtocolIDSql, protocolName);
 
@@ -3501,7 +3499,7 @@ public class DataSubscriber : InputAdapterBase
 
                                     if (protocolID == 0)
                                         protocolID = m_sttpProtocolID;
-#endif
+                                #endif
                                 }
 
                                 // For mutual subscriptions where this subscription is owner (i.e., internal is true), we only sync devices that we did not provide
@@ -3511,26 +3509,26 @@ public class DataSubscriber : InputAdapterBase
                                     // ownership is inferred by setting 'OriginalSource' to null. When gateway doesn't own device records (i.e., the "internal" flag is false), this means the device's measurements can only be consumed
                                     // locally - from a device record perspective this means the 'OriginalSource' field is set to the acronym of the PDC or PMU that generated the source measurements. This field allows a mirrored source
                                     // restriction to be implemented later to ensure all devices in an output protocol came from the same original source connection, if desired.
-                                    object originalSource = SyncIndependentDevices ? parentID.ToString() : Internal ? DBNull.Value :
-                                        string.IsNullOrEmpty(row.Field<string>("ParentAcronym")) ?
-                                            sourcePrefix + row.Field<string>("Acronym") :
+                                    object originalSource = SyncIndependentDevices ? parentID.ToString() : Internal ? DBNull.Value : 
+                                        string.IsNullOrEmpty(row.Field<string>("ParentAcronym")) ? 
+                                            sourcePrefix + row.Field<string>("Acronym") : 
                                             sourcePrefix + row.Field<string>("ParentAcronym");
 
                                     // Determine if device record already exists
                                     if (Convert.ToInt32(ExecuteScalar(command, deviceExistsSql, database.Guid(uniqueID))) == 0)
                                     {
-#if NET
+                                    #if NET
                                         // Insert new device record
                                         ExecuteNonQuery(command, insertDeviceSql, SyncIndependentDevices ? DBNull.Value : parentID,
                                             historianID, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"), originalSource,
                                             accessID, longitude, latitude, contactList.JoinKeyValuePairs(), connectionString, database.Bool(Internal));
-#else
+                                    #else
                                         // Insert new device record
-                                        ExecuteNonQuery(command, insertDeviceSql, database.Guid(m_nodeID), SyncIndependentDevices ? DBNull.Value : parentID,
-                                            historianID, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"), protocolID,
-                                            framesPerSecondFieldExists ? row.ConvertField<int>("FramesPerSecond") : 30, originalSource, accessID,
+                                        ExecuteNonQuery(command, insertDeviceSql, database.Guid(m_nodeID), SyncIndependentDevices ? DBNull.Value : parentID, 
+                                            historianID, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"), protocolID, 
+                                            framesPerSecondFieldExists ? row.ConvertField<int>("FramesPerSecond") : 30, originalSource, accessID, 
                                             longitude, latitude, contactList.JoinKeyValuePairs(), connectionString);
-#endif
+                                    #endif
 
                                         // Guids are normally auto-generated during insert - after insertion update the Guid so that it matches the source data. Most of the database
                                         // scripts have triggers that support properly assigning the Guid during an insert, but this code ensures the Guid will always get assigned.
@@ -3542,7 +3540,7 @@ public class DataSubscriber : InputAdapterBase
                                         if (Convert.ToInt32(ExecuteScalar(command, deviceIsUpdateableSql, database.Guid(uniqueID), parentIDValue)) > 0)
                                             continue;
 
-#if NET
+                                    #if NET
                                         // Update existing device record
                                         if (connectionStringFieldExists)
                                             ExecuteNonQuery(command, updateDeviceWithConnectionStringSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"),
@@ -3550,15 +3548,15 @@ public class DataSubscriber : InputAdapterBase
                                         else
                                             ExecuteNonQuery(command, updateDeviceSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"),
                                                 originalSource, historianID, accessID, longitude, latitude, contactList.JoinKeyValuePairs(), database.Bool(Internal), database.Guid(uniqueID));
-#else
+                                    #else
                                         // Update existing device record
                                         if (connectionStringFieldExists)
-                                            ExecuteNonQuery(command, updateDeviceWithConnectionStringSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"),
+                                            ExecuteNonQuery(command, updateDeviceWithConnectionStringSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"), 
                                                 originalSource, protocolID, framesPerSecondFieldExists ? row.ConvertField<int>("FramesPerSecond") : 30, historianID, accessID, longitude, latitude, contactList.JoinKeyValuePairs(), connectionString, database.Guid(uniqueID));
                                         else
-                                            ExecuteNonQuery(command, updateDeviceSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"),
+                                            ExecuteNonQuery(command, updateDeviceSql, sourcePrefix + row.Field<string>("Acronym"), row.Field<string>("Name"), 
                                                 originalSource, protocolID, framesPerSecondFieldExists ? row.ConvertField<int>("FramesPerSecond") : 30, historianID, accessID, longitude, latitude, contactList.JoinKeyValuePairs(), database.Guid(uniqueID));
-#endif
+                                    #endif
                                     }
                                 }
                             }
@@ -3585,22 +3583,22 @@ public class DataSubscriber : InputAdapterBase
                         string identityMeasurementExistsSql = database.ParameterizedQueryString("SELECT COUNT(*) FROM Measurement WHERE PointID = {0}", "pointID");
 
                         // Define SQL statement to insert new measurement record
-                        string insertMeasurementSql = database.ParameterizedQueryString("INSERT INTO Measurement(DeviceID, HistorianID, PointTag, AlternateTag, SignalTypeID, PhasorSourceIndex, SignalReference, Description, Internal, Subscribed, Enabled) " +
+                        string insertMeasurementSql = database.ParameterizedQueryString("INSERT INTO Measurement(DeviceID, HistorianID, PointTag, AlternateTag, SignalTypeID, PhasorSourceIndex, SignalReference, Description, Internal, Subscribed, Enabled) " + 
                                                                                         "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, 0, 1)", "deviceID", "historianID", "pointTag", "tempAlternateTagID", "signalTypeID", "phasorSourceIndex", "signalReference", "description", "internal");
 
                         // Define SQL statement to insert new measurement record
-                        string identityInsertMeasurementSql = database.ParameterizedQueryString("INSERT INTO Measurement(PointID, DeviceID, HistorianID, PointTag, AlternateTag, SignalTypeID, PhasorSourceIndex, SignalReference, Description, Internal, Subscribed, Enabled) " +
+                        string identityInsertMeasurementSql = database.ParameterizedQueryString("INSERT INTO Measurement(PointID, DeviceID, HistorianID, PointTag, AlternateTag, SignalTypeID, PhasorSourceIndex, SignalReference, Description, Internal, Subscribed, Enabled) " + 
                                                                                                 "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, 0, 1)", "pointID", "deviceID", "historianID", "pointTag", "tempAlternateTagID", "signalTypeID", "phasorSourceIndex", "signalReference", "description", "internal");
 
                         // Define SQL statement to update measurement's signal ID after insert, restoring original signal ID and alternate tag from meta-data
                         string updateMeasurementSignalIDSql = database.ParameterizedQueryString("UPDATE Measurement SET SignalID = {0}, AlternateTag = {1} WHERE AlternateTag = {2}", "signalID", "alternateTag", "tempAlternateTagID");
 
                         // Define SQL statement to update existing measurement record
-                        string updateMeasurementSql = database.ParameterizedQueryString("UPDATE Measurement SET HistorianID = {0}, PointTag = {1}, AlternateTag = {2}, SignalTypeID = {3}, PhasorSourceIndex = {4}, SignalReference = {5}, Description = {6}, Internal = {7} WHERE SignalID = {8}",
+                        string updateMeasurementSql = database.ParameterizedQueryString("UPDATE Measurement SET HistorianID = {0}, PointTag = {1}, AlternateTag = {2}, SignalTypeID = {3}, PhasorSourceIndex = {4}, SignalReference = {5}, Description = {6}, Internal = {7} WHERE SignalID = {8}", 
                             "historianID", "pointTag", "alternateTag", "signalTypeID", "phasorSourceIndex", "signalReference", "description", "internal", "signalID");
 
                         // Define SQL statement to update existing measurement record
-                        string identityUpdateMeasurementSql = database.ParameterizedQueryString("UPDATE Measurement SET DeviceID = {0}, HistorianID = {1}, PointTag = {2}, AlternateTag = {3}, SignalTypeID = {4}, PhasorSourceIndex = {5}, SignalReference = {6}, Description = {7}, Internal = {8}, Subscribed = 0, Enabled = 1, SignalID = {9} WHERE PointID = {10}",
+                        string identityUpdateMeasurementSql = database.ParameterizedQueryString("UPDATE Measurement SET DeviceID = {0}, HistorianID = {1}, PointTag = {2}, AlternateTag = {3}, SignalTypeID = {4}, PhasorSourceIndex = {5}, SignalReference = {6}, Description = {7}, Internal = {8}, Subscribed = 0, Enabled = 1, SignalID = {9} WHERE PointID = {10}", 
                             "deviceID", "historianID", "pointTag", "tempAlternateTagID", "signalTypeID", "phasorSourceIndex", "signalReference", "description", "internal", "signalID", "pointID");
 
                         // Define SQL statement to retrieve all measurement signal ID's for the current parent to check for mismatches - note that we use the ActiveMeasurements view
@@ -3809,13 +3807,13 @@ public class DataSubscriber : InputAdapterBase
                     // Check to see if data for the "PhasorDetail" table was included in the meta-data
                     if (metadata.Tables.Contains("PhasorDetail"))
                     {
-#if NET
+                    #if NET
                         const string PrimaryVoltageID = "PrimaryVoltageID";
                         const string DestinationPhasorID = "DestinationPhasorID";
-#else
+                    #else
                         const string PrimaryVoltageID = "DestinationPhasorID";
                         const string DestinationPhasorID = "PrimaryVoltageID";
-#endif
+                    #endif
 
                         DataTable phasorDetail = metadata.Tables["PhasorDetail"]!;
                         Dictionary<int, List<int>> definedSourceIndices = new();
@@ -3829,19 +3827,19 @@ public class DataSubscriber : InputAdapterBase
                         // Define SQL statement to query if phasor record is already defined (no Guid is defined for these simple label records)
                         string phasorExistsSql = database.ParameterizedQueryString("SELECT COUNT(*) FROM Phasor WHERE DeviceID = {0} AND SourceIndex = {1}", "deviceID", "sourceIndex");
 
-#if NET
+                    #if NET
                         // Define SQL statement to insert new phasor record
                         string insertPhasorSql = database.ParameterizedQueryString("INSERT INTO Phasor(DeviceID, Label, Type, Phase, SourceIndex, Internal) VALUES ({0}, {1}, {2}, {3}, {4}, {5})", "deviceID", "label", "type", "phase", "sourceIndex", "internal");
 
                         // Define SQL statement to update existing phasor record
                         string updatePhasorSql = database.ParameterizedQueryString("UPDATE Phasor SET Label = {0}, Type = {1}, Phase = {2}, Internal = {3} WHERE DeviceID = {4} AND SourceIndex = {5}", "label", "type", "phase", "internal", "deviceID", "sourceIndex");
-#else
+                    #else
                         // Define SQL statement to insert new phasor record
                         string insertPhasorSql = database.ParameterizedQueryString("INSERT INTO Phasor(DeviceID, Label, Type, Phase, SourceIndex) VALUES ({0}, {1}, {2}, {3}, {4})", "deviceID", "label", "type", "phase", "sourceIndex");
 
                         // Define SQL statement to update existing phasor record
                         string updatePhasorSql = database.ParameterizedQueryString("UPDATE Phasor SET Label = {0}, Type = {1}, Phase = {2} WHERE DeviceID = {3} AND SourceIndex = {4}", "label", "type", "phase", "deviceID", "sourceIndex");
-#endif
+                    #endif
 
                         // Define SQL statement to delete a phasor record
                         string deletePhasorSql = database.ParameterizedQueryString("DELETE FROM Phasor WHERE DeviceID = {0}", "deviceID");
@@ -3892,24 +3890,24 @@ public class DataSubscriber : InputAdapterBase
                                 // Determine if phasor record already exists
                                 if (Convert.ToInt32(ExecuteScalar(command, phasorExistsSql, deviceID, sourceIndex)) == 0)
                                 {
-#if NET
+                                #if NET
                                     // Insert new phasor record
                                     ExecuteNonQuery(command, insertPhasorSql, deviceID, row.Field<string>("Label") ?? "undefined", (row.Field<string>("Type") ?? "V").TruncateLeft(1), (row.Field<string>("Phase") ?? "+").TruncateLeft(1), sourceIndex, database.Bool(Internal));
-#else
+                                #else
                                     // Insert new phasor record
                                     ExecuteNonQuery(command, insertPhasorSql, deviceID, row.Field<string>("Label") ?? "undefined", (row.Field<string>("Type") ?? "V").TruncateLeft(1), (row.Field<string>("Phase") ?? "+").TruncateLeft(1), sourceIndex);
-#endif
+                                #endif
                                     updateRecord = true;
                                 }
                                 else if (recordNeedsUpdating)
                                 {
-#if NET
+                                #if NET
                                     // Update existing phasor record
                                     ExecuteNonQuery(command, updatePhasorSql, row.Field<string>("Label") ?? "undefined", (row.Field<string>("Type") ?? "V").TruncateLeft(1), (row.Field<string>("Phase") ?? "+").TruncateLeft(1), database.Bool(Internal), deviceID, sourceIndex);
-#else
+                                #else
                                     // Update existing phasor record
                                     ExecuteNonQuery(command, updatePhasorSql, row.Field<string>("Label") ?? "undefined", (row.Field<string>("Type") ?? "V").TruncateLeft(1), (row.Field<string>("Phase") ?? "+").TruncateLeft(1), deviceID, sourceIndex);
-#endif
+                                #endif
                                     updateRecord = true;
                                 }
 
@@ -3922,8 +3920,8 @@ public class DataSubscriber : InputAdapterBase
 
                                     // Using ConvertNullableField extension since publisher could use SQLite database in which case
                                     // all integers would arrive in data set as longs and need to be converted back to integers
-                                    int? destinationPhasorID = row.ConvertNullableField<int>(phasorDetailColumns.Contains(PrimaryVoltageID) ?
-                                        PrimaryVoltageID :
+                                    int? destinationPhasorID = row.ConvertNullableField<int>(phasorDetailColumns.Contains(PrimaryVoltageID) ? 
+                                        PrimaryVoltageID : 
                                         DestinationPhasorID);
 
                                     if (destinationPhasorID.HasValue)
@@ -4247,11 +4245,11 @@ public class DataSubscriber : InputAdapterBase
         {
             TcpServer tcpServerCommandChannel when tcpServerCommandChannel.TryGetClient(clientID, out TransportProvider<Socket>? tcpProvider) => tcpProvider?.Provider,
             TlsServer tlsServerCommandChannel when tlsServerCommandChannel.TryGetClient(clientID, out TransportProvider<TlsServer.TlsSocket>? tlsProvider) => tlsProvider?.Provider?.Socket,
-#if NET
+        #if NET
             _ => (m_clientCommandChannel as TcpClient)?.Client
-#else
+        #else
             _ => (m_clientCommandChannel as TcpClient)?.Client ?? (m_clientCommandChannel as TcpSimpleClient)?.Client
-#endif
+        #endif
         };
     }
 
@@ -4705,8 +4703,8 @@ public class DataSubscriber : InputAdapterBase
     /// <returns>File path within any defined logging path.</returns>
     protected string GetLoggingPath(string filePath)
     {
-        return string.IsNullOrWhiteSpace(m_loggingPath) ?
-            FilePath.GetAbsolutePath(filePath) :
+        return string.IsNullOrWhiteSpace(m_loggingPath) ? 
+            FilePath.GetAbsolutePath(filePath) : 
             Path.Combine(m_loggingPath, filePath);
     }
 
@@ -4775,8 +4773,8 @@ public class DataSubscriber : InputAdapterBase
         // Notify consumer that connection was successfully established
         OnConnectionEstablished();
 
-        OnStatusMessage(MessageLevel.Info, m_serverCommandChannel is null ?
-            "Data subscriber command channel connection to publisher was established." :
+        OnStatusMessage(MessageLevel.Info, m_serverCommandChannel is null ? 
+            "Data subscriber command channel connection to publisher was established." : 
             "Data subscriber server-based command channel established a new client connection from the publisher.");
 
         if (AutoConnect && Enabled)
@@ -4790,9 +4788,7 @@ public class DataSubscriber : InputAdapterBase
     {
         OnConnectionTerminated();
 
-        OnStatusMessage(MessageLevel.Info, m_serverCommandChannel is null ?
-            "Data subscriber command channel connection to publisher was terminated." :
-            "Data subscriber server-based command channel client connection from the publisher was terminated.");
+        OnStatusMessage(MessageLevel.Info, m_serverCommandChannel is null ? "Data subscriber command channel connection to publisher was terminated." : "Data subscriber server-based command channel client connection from the publisher was terminated.");
 
         DisconnectClient();
     }
@@ -5039,14 +5035,14 @@ public class DataSubscriber : InputAdapterBase
             // ReSharper disable once RedundantAssignment
             string localCertificate = null!;
 
-#if NET
+        #if NET
             localCertificate = ConfigSettings.Default[ConfigSettings.SystemSettingsCategory]["LocalCertificate"];
-#else
+        #else
             CategorizedSettingsElement localCertificateElement = ConfigurationFile.Current.Settings["systemSettings"]["LocalCertificate"];
-        
+
             if (localCertificateElement is not null)
                 localCertificate = localCertificateElement.Value;
-#endif
+        #endif
 
             if (localCertificate is null || !File.Exists(FilePath.GetAbsolutePath(localCertificate)))
                 throw new InvalidOperationException("Unable to find local certificate. Local certificate file must exist when using TLS security mode.");
@@ -5072,19 +5068,19 @@ public class DataSubscriber : InputAdapterBase
             if (File.Exists(FilePath.GetAbsolutePath(remoteCertificate)))
                 return true;
 
-#if NET
+        #if NET
             string remoteCertificatePath = ConfigSettings.Default[ConfigSettings.SystemSettingsCategory]["RemoteCertificatesPath"];
 
             if (string.IsNullOrWhiteSpace(remoteCertificatePath))
                 return false;
-#else
+        #else
             CategorizedSettingsElement remoteCertificateElement = ConfigurationFile.Current.Settings["systemSettings"]["RemoteCertificatesPath"];
 
             if (remoteCertificateElement is null)
                 return false;
 
             string remoteCertificatePath = remoteCertificateElement.Value;
-#endif
+        #endif
 
             remoteCertificate = Path.Combine(remoteCertificatePath, remoteCertificate);
 

--- a/src/lib/sttp.core/DataSubscriber.cs
+++ b/src/lib/sttp.core/DataSubscriber.cs
@@ -2859,16 +2859,39 @@ public class DataSubscriber : InputAdapterBase
                         int bufferCacheIndex = (int)(sequenceNumber - m_expectedBufferBlockSequenceNumber);
                         BufferBlockFlags bufferBlockFlags = (BufferBlockFlags)buffer[responseIndex + 4];
                         int signalCacheIndex = bufferBlockFlags.HasFlag(BufferBlockFlags.CacheIndex) ? 1 : 0;
+                        int bufferBlockKeyIndex = bufferBlockFlags.HasFlag(BufferBlockFlags.KeyIndex) ? 1 : 0;
                         bool payloadCompressed = bufferBlockFlags.HasFlag(BufferBlockFlags.Compressed);
+                        bool requireConfirmation = bufferBlockFlags.HasFlag(BufferBlockFlags.RequireConfirmation);
 
                         // Check if this buffer block has already been processed (e.g., mistaken retransmission due to timeout)
                         if (bufferCacheIndex >= 0 && (bufferCacheIndex >= m_bufferBlockCache.Count || m_bufferBlockCache[bufferCacheIndex] is null))
                         {
-                            // Send confirmation that buffer block is received
-                            SendServerCommand(ServerCommand.ConfirmBufferBlock, buffer.BlockCopy(responseIndex, 4));
+                            // Confirm only when the publisher set REQUIRE CONFIRMATION (IEEE 2664-2024 Table 8 bit 0x01).
+                            // Sequence-number bookkeeping below still proceeds either way so ordering / dropout detection
+                            // keeps working on fire-and-forget streams.
+                            if (requireConfirmation)
+                                SendServerCommand(ServerCommand.ConfirmBufferBlock, buffer.BlockCopy(responseIndex, 4));
+
+                            // Decrypt the encrypted region if cipher keys are active. Per IEEE Std 2664-2024 § 5.5.10
+                            // SEQUENCE VALUE and FLAGS are cleartext; SIGNAL INDEX and PAYLOAD are encrypted together.
+                            // This parallels the DATA PACKET decrypt path: the cipher key set is chosen by the
+                            // KeyIndex flag (Table 8 bit 0x04), matching DataPacketFlags.CipherIndex semantics.
+                            byte[] encryptedRegion = buffer;
+                            int encryptedOffset = responseIndex + 5;
+                            int encryptedLength = responseLength - 5;
+
+                            if (m_keyIVs is not null)
+                            {
+                                // Get a local copy of volatile keyIVs reference since this can change at any time
+                                keyIVs = m_keyIVs;
+
+                                encryptedRegion = Common.SymmetricAlgorithm.Decrypt(encryptedRegion, encryptedOffset, encryptedLength, keyIVs[bufferBlockKeyIndex][0], keyIVs[bufferBlockKeyIndex][1]);
+                                encryptedOffset = 0;
+                                encryptedLength = encryptedRegion.Length;
+                            }
 
                             // Get measurement key from signal index cache
-                            int signalIndex = BigEndian.ToInt32(buffer, responseIndex + 5);
+                            int signalIndex = BigEndian.ToInt32(encryptedRegion, encryptedOffset);
 
                             SignalIndexCache? signalIndexCache;
 
@@ -2879,14 +2902,15 @@ public class DataSubscriber : InputAdapterBase
                                 throw new InvalidOperationException($"Failed to find associated signal identification for runtime ID {signalIndex}");
 
                             // Decompress the payload if the publisher set the Compressed flag. GZip is the
-                            // always-available baseline per IEEE Std 2664-2024 Table 4 default.
+                            // always-available baseline per IEEE Std 2664-2024 Table 4 default. Note: compression
+                            // happens BEFORE encryption per IEEE 2664, so decryption happens before decompression.
                             byte[] payloadBuffer;
                             int payloadOffset;
                             int payloadLength;
 
                             if (payloadCompressed)
                             {
-                                using MemoryStream compressedStream = new(buffer, responseIndex + 9, responseLength - 9, writable: false);
+                                using MemoryStream compressedStream = new(encryptedRegion, encryptedOffset + 4, encryptedLength - 4, writable: false);
                                 using BlockAllocatedMemoryStream decompressedStream = new();
 
                                 using (GZipStream inflater = new(compressedStream, CompressionMode.Decompress, leaveOpen: true))
@@ -2898,14 +2922,16 @@ public class DataSubscriber : InputAdapterBase
                             }
                             else
                             {
-                                payloadBuffer = buffer;
-                                payloadOffset = responseIndex + 9;
-                                payloadLength = responseLength - 9;
+                                payloadBuffer = encryptedRegion;
+                                payloadOffset = encryptedOffset + 4;
+                                payloadLength = encryptedLength - 4;
                             }
 
                             BufferBlockMeasurement bufferBlockMeasurement = new(payloadBuffer, payloadOffset, payloadLength)
                             {
-                                Metadata = measurementKey.Metadata
+                                Metadata = measurementKey.Metadata,
+                                Flags = (byte)bufferBlockFlags,
+                                RequireConfirmation = requireConfirmation,
                             };
 
                             // Determine if this is the next buffer block in the sequence

--- a/src/lib/sttp.core/DataSubscriber.cs
+++ b/src/lib/sttp.core/DataSubscriber.cs
@@ -2848,10 +2848,18 @@ public class DataSubscriber : InputAdapterBase
                         }
                     case ServerResponse.BufferBlock:
                         {
-                            // Buffer block received - wrap as a buffer block measurement and expose back to consumer
-                            uint sequenceNumber = BigEndian.ToUInt32(buffer, responseIndex);
+                        // Buffer block received - wrap as a buffer block measurement and expose back to consumer.
+                        //
+                        // Wire layout (per IEEE Std 2664-2024 § 5.5.10 Figure 34 with SIGNAL INDEX per corrigendum)
+                        //   +0  uint32  SEQUENCE VALUE
+                        //   +4  byte    BUFFER BLOCK FLAGS (Table 8: 0x08 Compressed, 0x10 CacheIndex)
+                        //   +5  int32   SIGNAL INDEX
+                        //   +9  byte[]  payload (GZip-compressed when Compressed bit set)
+                        uint sequenceNumber = BigEndian.ToUInt32(buffer, responseIndex);
                             int bufferCacheIndex = (int)(sequenceNumber - m_expectedBufferBlockSequenceNumber);
-                            int signalCacheIndex = buffer[responseIndex + 4];
+                            BufferBlockFlags bufferBlockFlags = (BufferBlockFlags)buffer[responseIndex + 4];
+                            int signalCacheIndex = bufferBlockFlags.HasFlag(BufferBlockFlags.CacheIndex) ? 1 : 0;
+                            bool payloadCompressed = bufferBlockFlags.HasFlag(BufferBlockFlags.Compressed);
 
                             // Check if this buffer block has already been processed (e.g., mistaken retransmission due to timeout)
                             if (bufferCacheIndex >= 0 && (bufferCacheIndex >= m_bufferBlockCache.Count || m_bufferBlockCache[bufferCacheIndex] is null))
@@ -2870,8 +2878,32 @@ public class DataSubscriber : InputAdapterBase
                                 if (signalIndexCache is null || !signalIndexCache.Reference.TryGetValue(signalIndex, out MeasurementKey? measurementKey))
                                     throw new InvalidOperationException($"Failed to find associated signal identification for runtime ID {signalIndex}");
 
-                                // Skip the sequence number and signal index when creating the buffer block measurement
-                                BufferBlockMeasurement bufferBlockMeasurement = new(buffer, responseIndex + 9, responseLength - 9)
+                                // Decompress the payload if the publisher set the Compressed flag. GZip is the
+                                // always-available baseline per IEEE Std 2664-2024 Table 4 default.
+                                byte[] payloadBuffer;
+                                int payloadOffset;
+                                int payloadLength;
+
+                                if (payloadCompressed)
+                                {
+                                    using MemoryStream compressedStream = new(buffer, responseIndex + 9, responseLength - 9, writable: false);
+                                    using BlockAllocatedMemoryStream decompressedStream = new();
+
+                                    using (GZipStream inflater = new(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                                        inflater.CopyTo(decompressedStream);
+
+                                    payloadBuffer = decompressedStream.ToArray();
+                                    payloadOffset = 0;
+                                    payloadLength = payloadBuffer.Length;
+                                }
+                                else
+                                {
+                                    payloadBuffer = buffer;
+                                    payloadOffset = responseIndex + 9;
+                                    payloadLength = responseLength - 9;
+                                }
+
+                                BufferBlockMeasurement bufferBlockMeasurement = new(payloadBuffer, payloadOffset, payloadLength)
                                 {
                                     Metadata = measurementKey.Metadata
                                 };

--- a/src/lib/sttp.core/SubscriberAdapter.cs
+++ b/src/lib/sttp.core/SubscriberAdapter.cs
@@ -698,9 +698,8 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
             {
                 if (measurement is BufferBlockMeasurement { Buffer: not null } bufferBlockMeasurement)
                 {
-                    // Still sending buffer block measurements to client; we are expecting
-                    // confirmations which will indicate whether retransmission is necessary,
-                    // so we will restart the retransmission timer
+                    // Pause the retransmission timer while we emit. If this block requires
+                    // confirmation we'll restart it on the way out; if not, we leave it stopped.
                     m_bufferBlockRetransmissionTimer.Stop();
 
                     // Send the buffer block - the helper handles framing (sequence, IEEE flags
@@ -708,14 +707,16 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
                     // the payload when the session has payload compression enabled.
                     SendBufferBlockMeasurement(bufferBlockMeasurement, signalIndexCache, currentCacheIndex, compressPayload: false, out byte[] bufferBlock);
 
-                    lock (m_bufferBlockCacheLock)
+                    // REQUIRE CONFIRMATION (Table 8 bit 0x01) gates retransmission. When the
+                    // application opted out (RequireConfirmation == false), the block is
+                    // fire-and-forget: no cache entry, no retransmission timer.
+                    if (bufferBlockMeasurement.RequireConfirmation)
                     {
-                        // Cache buffer block for retransmission
-                        m_bufferBlockCache.Add(bufferBlock);
-                    }
+                        lock (m_bufferBlockCacheLock)
+                            m_bufferBlockCache.Add(bufferBlock);
 
-                    // Start the retransmission timer in case we never receive a confirmation
-                    m_bufferBlockRetransmissionTimer.Start();
+                        m_bufferBlockRetransmissionTimer.Start();
+                    }
                 }
                 else
                 {
@@ -833,6 +834,12 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
         if (currentCacheIndex == 1)
             flags |= BufferBlockFlags.CacheIndex;
 
+        // REQUIRE CONFIRMATION (Table 8 bit 0x01): when set, the subscriber is required to emit a
+        // CONFIRM BUFFER BLOCK command on receipt; this is also the trigger that gates whether the
+        // caller below caches the frame for retransmission and arms the retransmission timer.
+        if (bufferBlockMeasurement.RequireConfirmation)
+            flags |= BufferBlockFlags.RequireConfirmation;
+
         // Optionally GZip-compress the payload. Default algorithm per IEEE Std 2664-2024 is GZip;
         // selection is configurable at the session level via the BufferBlockPayloadCompressionAlgorithms
         // operational mode key, but we hard-code GZip here as the always-available baseline.
@@ -926,10 +933,16 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
                         m_bufferBlockRetransmissionTimer.Stop();
                         SendBufferBlockMeasurement(bufferBlockMeasurement, signalIndexCache, currentCacheIndex, compressPayload: true, out byte[] bufferBlock);
 
-                        lock (m_bufferBlockCacheLock)
-                            m_bufferBlockCache.Add(bufferBlock);
+                        // Cache + retransmit only when the application asked for it; otherwise the
+                        // block is fire-and-forget (no cache, timer stays stopped).
+                        if (bufferBlockMeasurement.RequireConfirmation)
+                        {
+                            lock (m_bufferBlockCacheLock)
+                                m_bufferBlockCache.Add(bufferBlock);
 
-                        m_bufferBlockRetransmissionTimer.Start();
+                            m_bufferBlockRetransmissionTimer.Start();
+                        }
+
                         continue;
                     }
 

--- a/src/lib/sttp.core/SubscriberAdapter.cs
+++ b/src/lib/sttp.core/SubscriberAdapter.cs
@@ -95,6 +95,11 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
     private SharedTimer m_bufferBlockRetransmissionTimer = null!;
     private double m_bufferBlockRetransmissionTimeout;
 
+    // Per-buffer-block header that travels inside the BUFFER BLOCK response payload, immediately
+    // before the free-form bytes. Matches IEEE Std 2664-2024 § 5.5.10 Figure 34 (SEQUENCE VALUE +
+    // BUFFER BLOCK FLAGS + 4-byte SIGNAL INDEX per corrigendum)
+    private const int BufferBlockMeasurementHeaderSize = 4 /* sequence */ + 1 /* flags */ + 4 /* signal index */;
+
     private bool m_disposed;
 
 #endregion
@@ -667,9 +672,6 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
         // Includes data packet flags and measurement count
         const int PacketHeaderSize = DataPublisher.ClientResponseHeaderSize + 5;
 
-        // Includes sequence number and buffer block flags
-        const int BufferBlockHeaderSize = DataPublisher.ClientResponseHeaderSize + 5;
-
         try
         {
             if (!Enabled)
@@ -701,23 +703,10 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
                     // so we will restart the retransmission timer
                     m_bufferBlockRetransmissionTimer.Stop();
 
-                    // Handle buffer block measurements as a special case - this can be any kind of data,
-                    // measurement subscriber will need to know how to interpret buffer
-                    byte[] bufferBlock = new byte[BufferBlockHeaderSize + 4 + bufferBlockMeasurement.Length];
-                    int index = 0;
-
-                    // Prepend sequence number
-                    index += BigEndian.CopyBytes(m_bufferBlockSequenceNumber, bufferBlock, index);
-                    m_bufferBlockSequenceNumber++;
-
-                    // Copy signal index into buffer
-                    bufferBlock[index++] = (byte)currentCacheIndex;
-                    int bufferBlockSignalIndex = signalIndexCache.GetSignalIndex(bufferBlockMeasurement.Key);
-                    index += BigEndian.CopyBytes(bufferBlockSignalIndex, bufferBlock, index);
-
-                    // Append measurement data and send
-                    Buffer.BlockCopy(bufferBlockMeasurement.Buffer, 0, bufferBlock, index, bufferBlockMeasurement.Length);
-                    m_parent.SendClientResponse(ClientID, ServerResponse.BufferBlock, ServerCommand.Subscribe, bufferBlock);
+                    // Send the buffer block - the helper handles framing (sequence, IEEE flags
+                    // byte, signal index, then the opaque payload) and applies GZip compression to
+                    // the payload when the session has payload compression enabled.
+                    SendBufferBlockMeasurement(bufferBlockMeasurement, signalIndexCache, currentCacheIndex, compressPayload: false, out byte[] bufferBlock);
 
                     lock (m_bufferBlockCacheLock)
                     {
@@ -802,6 +791,85 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
         m_lastPublishTime = DateTime.UtcNow.Ticks;
     }
 
+    /// <summary>
+    /// Builds the per-IEEE-2664 BUFFER BLOCK response payload for a single <see cref="BufferBlockMeasurement"/>,
+    /// sends it to the client, and outputs the constructed byte array so the caller can cache it for retransmission.
+    /// </summary>
+    /// <param name="bufferBlockMeasurement">Source measurement; its <see cref="BufferBlockMeasurement.Buffer"/> supplies the opaque payload.</param>
+    /// <param name="signalIndexCache">Active signal index cache - used to resolve the measurement key to the 32-bit runtime ID embedded in the frame.</param>
+    /// <param name="currentCacheIndex">Which signal index cache (even=0 or odd=1) is in use. Sets <see cref="BufferBlockFlags.CacheIndex"/> when non-zero.</param>
+    /// <param name="compressPayload">
+    /// When true, the payload bytes are GZip-compressed and the <see cref="BufferBlockFlags.Compressed"/>
+    /// flag is set on the wire. GZip is the IEEE Std 2664-2024 default for buffer-block payload compression
+    /// (Annex / Table 4 <c>BufferBlockPayloadCompressionAlgorithms</c>).
+    /// </param>
+    /// <param name="bufferBlock">
+    /// The constructed on-wire byte array. Caller is responsible for inserting this into the retransmission cache;
+    /// the helper itself does not touch the cache.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Wire layout matches IEEE Std 2664-2024 § 5.5.10 Figure 34
+    /// <code>
+    ///     +0  uint32  SEQUENCE VALUE      (big-endian, ack tracker)
+    ///     +4  byte    BUFFER BLOCK FLAGS  (Table 8 - 0x01 RequireConfirmation, 0x08 Compressed, 0x10 CacheIndex)
+    ///     +5  int32   SIGNAL INDEX        (big-endian, runtime ID -- per IEEE 2664 corrigendum)
+    ///     +9  byte[]  PAYLOAD             (opaque; GZip-compressed when Compressed bit is set)
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Future implementations will parse buffer block compression algorithm from BufferBlockPayloadCompressionAlgorithms
+    /// connection string parameter key in Define Operational Modes per IEEE 2264. Current implementation defaults to GZip.
+    /// </para>
+    /// </remarks>
+    private void SendBufferBlockMeasurement(BufferBlockMeasurement bufferBlockMeasurement, SignalIndexCache signalIndexCache, int currentCacheIndex, bool compressPayload, out byte[] bufferBlock)
+    {
+        byte[] sourceBuffer = bufferBlockMeasurement.Buffer!;
+        int sourceOffset = 0;
+        int sourceLength = bufferBlockMeasurement.Length;
+
+        BufferBlockFlags flags = BufferBlockFlags.NoFlags;
+
+        if (currentCacheIndex == 1)
+            flags |= BufferBlockFlags.CacheIndex;
+
+        // Optionally GZip-compress the payload. Default algorithm per IEEE Std 2664-2024 is GZip;
+        // selection is configurable at the session level via the BufferBlockPayloadCompressionAlgorithms
+        // operational mode key, but we hard-code GZip here as the always-available baseline.
+        if (compressPayload)
+        {
+            using BlockAllocatedMemoryStream compressedStream = new();
+
+            using (GZipStream deflater = new(compressedStream, CompressionLevel.Fastest, leaveOpen: true))
+                deflater.Write(sourceBuffer, 0, sourceLength);
+
+            byte[] compressed = compressedStream.ToArray();
+            sourceBuffer = compressed;
+            sourceOffset = 0;
+            sourceLength = compressed.Length;
+            flags |= BufferBlockFlags.Compressed;
+        }
+
+        bufferBlock = new byte[BufferBlockMeasurementHeaderSize + sourceLength];
+        int index = 0;
+
+        // SEQUENCE VALUE (4 bytes, uint32)
+        index += BigEndian.CopyBytes(m_bufferBlockSequenceNumber, bufferBlock, index);
+        m_bufferBlockSequenceNumber++;
+
+        // BUFFER BLOCK FLAGS (1 byte)
+        bufferBlock[index++] = (byte)flags;
+
+        // SIGNAL INDEX (4 bytes, int32)
+        int signalIndex = signalIndexCache.GetSignalIndex(bufferBlockMeasurement.Key);
+        index += BigEndian.CopyBytes(signalIndex, bufferBlock, index);
+
+        // PAYLOAD (opaque)
+        Buffer.BlockCopy(sourceBuffer, sourceOffset, bufferBlock, index, sourceLength);
+
+        m_parent.SendClientResponse(ClientID, ServerResponse.BufferBlock, ServerCommand.Subscribe, bufferBlock);
+    }
+
     private void ProcessTSSCMeasurements(IEnumerable<IMeasurement> measurements)
     {
         SignalIndexCache? signalIndexCache;
@@ -840,11 +908,36 @@ internal class SubscriberAdapter : FacileActionAdapterBase, IClientSubscription
 
                 foreach (IMeasurement measurement in measurements)
                 {
+                    // BufferBlockMeasurement cannot flow through the TSSC encoder (which only
+                    // understands the 32-byte time-series measurement structure). Per IEEE Std
+                    // 2664-2024, buffer-block payloads under a compressed session use the
+                    // negotiated buffer-block compression algorithm - default GZip - rather than
+                    // the streaming compression. Flush any pending TSSC payload first to preserve
+                    // ordering, then emit the buffer block on its own response frame.
+                    if (measurement is BufferBlockMeasurement { Buffer: not null } bufferBlockMeasurement)
+                    {
+                        if (count > 0)
+                        {
+                            SendTSSCPayload(count, currentCacheIndex);
+                            count = 0;
+                            m_tsscEncoder.SetBuffer(m_tsscWorkingBuffer, 0, m_tsscWorkingBuffer.Length);
+                        }
+
+                        m_bufferBlockRetransmissionTimer.Stop();
+                        SendBufferBlockMeasurement(bufferBlockMeasurement, signalIndexCache, currentCacheIndex, compressPayload: true, out byte[] bufferBlock);
+
+                        lock (m_bufferBlockCacheLock)
+                            m_bufferBlockCache.Add(bufferBlock);
+
+                        m_bufferBlockRetransmissionTimer.Start();
+                        continue;
+                    }
+
                     int index = signalIndexCache.GetSignalIndex(measurement.Key);
 
-                    if (index == int.MaxValue) 
+                    if (index == int.MaxValue)
                         continue; // Ignore unmapped signal
-                    
+
                     if (!m_tsscEncoder.TryAddMeasurement(index, measurement.Timestamp.Value, (uint)measurement.StateFlags, (float)measurement.AdjustedValue))
                     {
                         SendTSSCPayload(count, currentCacheIndex);


### PR DESCRIPTION
Updated buffer block support to match IEEE 2664 specifications.

Note 4-byte SIGNAL INDEX support added in advance of IEEE 2664 corrigendum approval -- this is required for proper implementation.

Since STTP buffer blocks have not been officially used in production deployments, no attempt has been made to worry about backwards compatibility.

This matches Python implementation. Test code to verify `gsfapi` -> `gsfapi` and `gsfapi` -> `pyapi` interop can be found here:
https://github.com/sttp/test-interop
