### PR TITLE
Fix reverse connection recovery

### DIFF
--- a/src/lib/sttp.core/Common.cs
+++ b/src/lib/sttp.core/Common.cs
@@ -23,11 +23,7 @@
 //
 //******************************************************************************************************
 
-#if NET
-#define MONO
-#endif
-
-#if !MONO
+#if !NET
 using Microsoft.Win32;
 #endif
 
@@ -40,7 +36,7 @@ public static class Common
 {
     static Common()
     {
-    #if MONO
+    #if NET || MONO
         UseManagedEncryption = true;
     #else
         const string FipsKeyOld = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa";

--- a/src/lib/sttp.core/DataPublisher.cs
+++ b/src/lib/sttp.core/DataPublisher.cs
@@ -1671,7 +1671,7 @@ public class DataPublisher : ActionAdapterCollection, IOptimizedRoutingConsumer
                     PayloadAware = true,
                     PayloadMarker = null,
                     PayloadEndianOrder = EndianOrder.BigEndian,
-                    MaxConnectionAttempts = 1,
+                    MaxConnectionAttempts = -1,
                     CertificateFile = FilePath.GetAbsolutePath(localCertificate!),
                     CheckCertificateRevocation = checkCertificateRevocation,
                     CertificateChecker = m_certificateChecker,

--- a/src/lib/sttp.core/DataSubscriber.cs
+++ b/src/lib/sttp.core/DataSubscriber.cs
@@ -2580,7 +2580,7 @@ public class DataSubscriber : InputAdapterBase
                         if (TotalBytesReceived == 0)
                         {
                             // At the point when data is being received, data monitor should be enabled
-                            if (m_dataStreamMonitor is not null && m_dataStreamMonitor.Enabled)
+                            if (m_dataStreamMonitor is not null && !m_dataStreamMonitor.Enabled)
                                 m_dataStreamMonitor.Enabled = true;
 
                             // Establish run-time log for subscriber
@@ -2609,7 +2609,7 @@ public class DataSubscriber : InputAdapterBase
 
                         // Track total data packet bytes received from any channel
                         TotalBytesReceived += m_lastBytesReceived;
-                        m_monitoredBytesReceived += m_lastBytesReceived;
+                        Interlocked.Add(ref m_monitoredBytesReceived, m_lastBytesReceived);
 
                         // Get data packet flags
                         DataPacketFlags flags = (DataPacketFlags)buffer[responseIndex];
@@ -4214,6 +4214,9 @@ public class DataSubscriber : InputAdapterBase
     // Disconnect client, restarting if disconnect was not intentional
     private void DisconnectClient()
     {
+        if (m_dataStreamMonitor is not null)
+            m_dataStreamMonitor.Enabled = false;
+
         // Mark end of any data transmission in run-time log
         if (m_runTimeLog is not null && m_runTimeLog.Enabled)
         {
@@ -4245,12 +4248,14 @@ public class DataSubscriber : InputAdapterBase
         }
         else
         {
-            if (m_activeClientID != Guid.Empty)
-                m_serverCommandChannel.DisconnectOne(m_activeClientID);
+            Guid activeClientID = m_activeClientID;
+            m_activeClientID = Guid.Empty;
+
+            if (activeClientID != Guid.Empty)
+                m_serverCommandChannel.DisconnectOne(activeClientID);
 
             // When subscriber is in server mode, the server does not need to be restarted, but we
             // will reset client statistics - this is a server of "one" client, the publisher
-            m_activeClientID = Guid.Empty;
             m_subscribedDevicesTimer?.Stop();
             m_metadataRefreshPending = false;
             m_expectedBufferBlockSequenceNumber = 0u;
@@ -4736,12 +4741,12 @@ public class DataSubscriber : InputAdapterBase
 
     private void DataStreamMonitor_Elapsed(object? sender, EventArgs<DateTime> e)
     {
-        bool dataReceived = m_monitoredBytesReceived > 0;
+        bool dataReceived = Interlocked.Exchange(ref m_monitoredBytesReceived, 0L) > 0;
 
         if (m_dataChannel is null && m_metadataRefreshPending)
         {
             if (m_lastReceivedAt > DateTime.MinValue)
-                dataReceived = (DateTime.UtcNow - m_lastReceivedAt).Seconds < DataLossInterval;
+                dataReceived = (DateTime.UtcNow - m_lastReceivedAt).TotalSeconds < DataLossInterval;
         }
 
         if (!dataReceived)
@@ -4758,9 +4763,6 @@ public class DataSubscriber : InputAdapterBase
                     DisconnectClient();
             });
         }
-
-        // Reset bytes received bytes being monitored
-        m_monitoredBytesReceived = 0L;
     }
 
     private void RunTimeLog_ProcessException(object? sender, EventArgs<Exception> e)

--- a/src/lib/sttp.core/DataSubscriber.cs
+++ b/src/lib/sttp.core/DataSubscriber.cs
@@ -3156,7 +3156,7 @@ public class DataSubscriber : InputAdapterBase
 
             Measurement measurement = new()
             {
-                Metadata = key!.Metadata,
+                Metadata = key.Metadata,
                 Timestamp = time,
                 StateFlags = (MeasurementStateFlags)quality,
                 Value = value

--- a/src/lib/sttp.gsf/Properties/AssemblyInfo.cs
+++ b/src/lib/sttp.gsf/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/lib/sttp.gsf/internal/RequiredMemberAttribute.cs
+++ b/src/lib/sttp.gsf/internal/RequiredMemberAttribute.cs
@@ -1,7 +1,6 @@
 ﻿#pragma warning disable
 
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
 
     namespace System.Runtime.CompilerServices
     {


### PR DESCRIPTION
When using a reverse connection, the subscriber is the server/listener and therefore owns the only reliable application-level indication that published data has stopped arriving. The intended data monitor was gated by an inverted condition: it attempted to enable the timer only when the timer was already enabled. As a result, a half-open connection -- such as one left behind by a temporary firewall outage -- could remain established without the subscriber forcing the publisher client through its normal reconnect cycle.

The reverse recovery path now uses the existing transport behavior:

1. The subscriber detects no data for `DataLossInterval`
2. The subscriber calls `DisconnectOne` for its sole publisher connection
3. The publisher's TCP/TLS client detects termination
4. The existing publisher handler invokes `ConnectAsync`
5. Native unlimited connection attempts continue until the subscriber is reachable

With change, reverse STTP connections can recover when the transport remains half-open but measurement data has stopped flowing. Normal subscriber/client-to-publisher/server operation is unchanged.